### PR TITLE
Add debug mode diagnostics

### DIFF
--- a/.github/agents/integration-test.agent.md
+++ b/.github/agents/integration-test.agent.md
@@ -19,10 +19,15 @@ Validate latest main branch behavior from a user perspective and catch regressio
    - `go build -o /tmp/gh-agent-viz ./gh-agent-viz.go`
 2. CLI smoke:
    - `/tmp/gh-agent-viz --help`
-3. Behavior checks (when environment supports gh auth + agent data):
+   - `/tmp/gh-agent-viz --debug --help`
+3. Debug diagnostics checks:
+   - run a failing path with debug enabled (for example, invalid repo scope) and confirm debug output points to the log file path
+   - verify debug log file `~/.gh-agent-viz-debug.log` is created and includes command/status/output entries
+4. Behavior checks (when environment supports gh auth + agent data):
    - launch TUI and verify board renders
    - verify navigation keys (`h/right/j/k`)
    - verify actions (`enter`, `l`, `o`) do not error unexpectedly
+   - verify debug-mode errors include guidance to the debug log location
 
 ## Reporting format
 - PASS/FAIL summary

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ gh agent-viz
 gh agent-viz --repo owner/repo
 ```
 
+### Enable Debug Mode
+
+```bash
+gh agent-viz --debug
+```
+
+Debug mode writes command diagnostics to `~/.gh-agent-viz-debug.log` to speed up troubleshooting.
+
 ### Keyboard Shortcuts
 
 | Key | Action |

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,12 +5,14 @@ import (
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/maxbeizer/gh-agent-viz/internal/data"
 	"github.com/maxbeizer/gh-agent-viz/internal/tui"
 	"github.com/spf13/cobra"
 )
 
 var (
-	repoFlag string
+	repoFlag  string
+	debugFlag bool
 )
 
 // rootCmd represents the base command
@@ -20,10 +22,12 @@ var rootCmd = &cobra.Command{
 	Long: `gh-agent-viz is a GitHub CLI extension that provides an interactive
 terminal UI for visualizing and managing GitHub Copilot coding agent sessions.
 
-View agent task status, browse details, and review logs in an easy-to-use TUI.`,
+	View agent task status, browse details, and review logs in an easy-to-use TUI.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		data.SetDebug(debugFlag)
+
 		// Create the Bubble Tea program
-		model := tui.NewModel(repoFlag)
+		model := tui.NewModel(repoFlag, debugFlag)
 		p := tea.NewProgram(model, tea.WithAltScreen())
 
 		// Run the program
@@ -45,4 +49,5 @@ func Execute() {
 func init() {
 	// Add flags
 	rootCmd.Flags().StringVarP(&repoFlag, "repo", "R", "", "Scope to a specific repository (format: owner/repo)")
+	rootCmd.Flags().BoolVar(&debugFlag, "debug", false, "Enable debug diagnostics and write command logs to ~/.gh-agent-viz-debug.log")
 }

--- a/internal/data/agentapi.go
+++ b/internal/data/agentapi.go
@@ -3,7 +3,9 @@ package data
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -11,6 +13,23 @@ import (
 
 // execCommand is a variable to allow mocking exec.Command in tests.
 var execCommand = exec.Command
+var debugEnabled bool
+
+const debugLogFileName = ".gh-agent-viz-debug.log"
+
+// SetDebug enables or disables debug logging for data-layer command execution.
+func SetDebug(enabled bool) {
+	debugEnabled = enabled
+}
+
+// DebugLogPath returns the location of the debug log file.
+func DebugLogPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return debugLogFileName
+	}
+	return filepath.Join(home, debugLogFileName)
+}
 
 // AgentTask represents a GitHub Copilot agent task session
 type AgentTask struct {
@@ -31,7 +50,7 @@ func FetchAgentTasks(repo string) ([]AgentTask, error) {
 	if repo != "" {
 		jsonArgs = append(jsonArgs, "-R", repo)
 	}
-	jsonOutput, jsonErr := execCommand("gh", jsonArgs...).CombinedOutput()
+	jsonOutput, jsonErr := runGH(jsonArgs...)
 	if jsonErr == nil {
 		var tasks []AgentTask
 		if err := json.Unmarshal(jsonOutput, &tasks); err != nil {
@@ -45,7 +64,7 @@ func FetchAgentTasks(repo string) ([]AgentTask, error) {
 		return nil, fmt.Errorf("failed to fetch agent tasks: %s", strings.TrimSpace(string(jsonOutput)))
 	}
 
-	output, err := execCommand("gh", "agent-task", "list").CombinedOutput()
+	output, err := runGH("agent-task", "list")
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch agent tasks: %s", strings.TrimSpace(string(output)))
 	}
@@ -97,7 +116,7 @@ func FetchAgentTaskDetail(id string, repo string) (*AgentTask, error) {
 		args = append(args, "-R", repo)
 	}
 
-	output, err := execCommand("gh", args...).CombinedOutput()
+	output, err := runGH(args...)
 	if err == nil {
 		var task AgentTask
 		if err := json.Unmarshal(output, &task); err != nil {
@@ -116,7 +135,7 @@ func FetchAgentTaskDetail(id string, repo string) (*AgentTask, error) {
 		prArgs = append(prArgs, "-R", repo)
 	}
 
-	prOutput, prErr := execCommand("gh", prArgs...).CombinedOutput()
+	prOutput, prErr := runGH(prArgs...)
 	if prErr != nil {
 		return nil, fmt.Errorf("failed to fetch agent task detail: %s", strings.TrimSpace(string(prOutput)))
 	}
@@ -158,7 +177,7 @@ func FetchAgentTaskLog(id string, repo string) (string, error) {
 		args = append(args, "-R", repo)
 	}
 
-	output, err := execCommand("gh", args...).CombinedOutput()
+	output, err := runGH(args...)
 	if err != nil {
 		trimmed := strings.TrimSpace(string(output))
 		if strings.Contains(trimmed, "session ID is required") {
@@ -184,4 +203,34 @@ func normalizeStatus(status string) string {
 	default:
 		return normalized
 	}
+}
+
+func runGH(args ...string) ([]byte, error) {
+	output, err := execCommand("gh", args...).CombinedOutput()
+	if debugEnabled {
+		logDebugEntry(args, output, err)
+	}
+	return output, err
+}
+
+func logDebugEntry(args []string, output []byte, cmdErr error) {
+	f, err := os.OpenFile(DebugLogPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	status := "ok"
+	if cmdErr != nil {
+		status = cmdErr.Error()
+	}
+
+	_, _ = fmt.Fprintf(
+		f,
+		"[%s] gh %s\nstatus: %s\noutput:\n%s\n---\n",
+		time.Now().Format(time.RFC3339),
+		strings.Join(args, " "),
+		status,
+		strings.TrimSpace(string(output)),
+	)
 }

--- a/internal/tui/context.go
+++ b/internal/tui/context.go
@@ -8,6 +8,7 @@ type ProgramContext struct {
 	Width        int
 	Height       int
 	Error        error
+	Debug        bool
 	StatusFilter string // "all", "active", "completed", "failed"
 }
 

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -43,8 +43,9 @@ type Model struct {
 }
 
 // NewModel creates a new TUI model
-func NewModel(repo string) Model {
+func NewModel(repo string, debug bool) Model {
 	ctx := NewProgramContext()
+	ctx.Debug = debug
 	cfg, err := config.Load("")
 	if err == nil {
 		ctx.Config = cfg
@@ -172,7 +173,11 @@ func (m Model) View() string {
 	}
 
 	if m.ctx.Error != nil {
-		mainView = fmt.Sprintf("Error: %v\n\n%s", m.ctx.Error, mainView)
+		errorText := fmt.Sprintf("Error: %v", m.ctx.Error)
+		if m.ctx.Debug {
+			errorText = fmt.Sprintf("%s\nDebug mode enabled. Log file: %s", errorText, data.DebugLogPath())
+		}
+		mainView = fmt.Sprintf("%s\n\n%s", errorText, mainView)
 	}
 
 	return headerView + mainView + footerView


### PR DESCRIPTION
## Summary
- add --debug CLI flag for diagnostic mode
- write gh command diagnostics to ~/.gh-agent-viz-debug.log
- surface debug log location in UI error messaging
- update integration test agent and README for debug workflow

## Testing
- go test ./...
- go build -o /tmp/gh-agent-viz ./gh-agent-viz.go
- /tmp/gh-agent-viz --debug --help