### PR TITLE
Add whimsical first-state copy

### DIFF
--- a/internal/tui/components/tasklist/tasklist.go
+++ b/internal/tui/components/tasklist/tasklist.go
@@ -61,11 +61,11 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 // View renders the sessions as a kanban board
 func (m Model) View() string {
 	if m.loading {
-		return m.titleStyle.Render("Loading sessions...")
+		return m.titleStyle.Render("Warming up the radar...\n\nCollecting fresh session telemetry.")
 	}
 
 	if len(m.sessions) == 0 {
-		return m.titleStyle.Render("No sessions found\n\nTry: refresh with 'r' or toggle filter with Tab/Shift+Tab")
+		return m.titleStyle.Render("The sky is clear — no active flights yet.\n\nPress 'r' to scan again, or Tab/Shift+Tab to check other lanes.")
 	}
 
 	overview := m.renderOverview()

--- a/internal/tui/components/tasklist/tasklist_test.go
+++ b/internal/tui/components/tasklist/tasklist_test.go
@@ -106,12 +106,12 @@ func TestViewShowsKanbanColumns(t *testing.T) {
 
 func TestViewEmptyAndLoadingStates(t *testing.T) {
 	model := newModel()
-	if got := model.View(); !strings.Contains(got, "No sessions found") {
+	if got := model.View(); !strings.Contains(got, "The sky is clear") {
 		t.Fatalf("expected empty state, got: %s", got)
 	}
 
 	model.loading = true
-	if got := model.View(); !strings.Contains(got, "Loading sessions") {
+	if got := model.View(); !strings.Contains(got, "Warming up the radar") {
 		t.Fatalf("expected loading state, got: %s", got)
 	}
 }
@@ -207,10 +207,10 @@ func TestView_ImprovedEmptyState(t *testing.T) {
 	)
 
 	view := model.View()
-	if !strings.Contains(view, "No sessions found") {
+	if !strings.Contains(view, "The sky is clear") {
 		t.Error("expected improved empty state message")
 	}
-	if !strings.Contains(view, "refresh with 'r'") {
+	if !strings.Contains(view, "Press 'r' to scan again") {
 		t.Error("expected empty state to include helpful hints")
 	}
 }

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -157,7 +157,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // View renders the TUI
 func (m Model) View() string {
 	if !m.ready {
-		return "Initializing..."
+		return "Spinning up ATC tower..."
 	}
 
 	// Update footer hints based on current context

--- a/internal/tui/ui_test.go
+++ b/internal/tui/ui_test.go
@@ -212,3 +212,11 @@ func TestHandleListKeys_LocalSessionLogShowsHelpfulError(t *testing.T) {
 		t.Fatal("expected helpful error for local session logs")
 	}
 }
+
+func TestView_NotReadyShowsWhimsicalStartupText(t *testing.T) {
+	m := NewModel("", false)
+	view := m.View()
+	if view != "Spinning up ATC tower..." {
+		t.Fatalf("expected startup text, got %q", view)
+	}
+}


### PR DESCRIPTION
## Summary\n- replace flat startup text with playful ATC-themed copy\n- refresh loading and empty-state text with whimsical tone + clear actions\n- update tests for startup/loading/empty state strings\n\n## Validation\n- go test ./...\n- make smoke