### PR TITLE
Improve at-a-glance session cards and selected-session panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ An interactive terminal UI for visualizing GitHub Copilot coding agent sessions.
 ## Features
 
 - 📊 **Interactive TUI** - Browse agent sessions with keyboard navigation
-- 🛩️ **ATC Overview + Flight Deck** - Live session counters and selected-session command hints
+- 🛩️ **ATC Overview + Selected Session panel** - Live counters plus plain-language details/actions for the highlighted row
 - 🔍 **Task Details** - View comprehensive task metadata (status, repo, branch, PR links)
 - 📝 **Log Viewer** - Scrollable, searchable agent task logs
 - 💻 **Local Sessions** - Automatically ingests local Copilot CLI sessions from `~/.copilot/session-state/`
 - 🎨 **Status Indicators** - Color-coded status icons (running, queued, completed, failed)
 - 🧑 **Input Needed Detection** - Highlights sessions that appear blocked waiting for human input
+- 🚦 **Attention Reasons** - Every card includes an explicit `Attention:` reason (`needs your input`, `failed`, `active but quiet`, or `no action needed`)
 - ⚡ **Quick Actions** - Open PRs in browser, refresh data, filter by status
 - 🔄 **Resume Sessions** - Jump directly into active Copilot CLI sessions with one keystroke
 - ⌨️ **Vim-style Keys** - j/k navigation, familiar keybindings
@@ -88,6 +89,15 @@ When enabled, the UI also shows a persistent debug banner with the log path.
 Press `s` on any active **local Copilot CLI session** (status: `running` or `queued`) to resume it directly in your terminal. This executes `gh copilot -- --resume <session-id>` and drops you into the Copilot CLI session.
 
 **Note:** Only active local sessions can be resumed. Attempting to resume a remote agent-task row, or a completed/failed session, shows a clear error message.
+
+### At-a-glance card semantics
+
+Each session card is intentionally labeled for quick triage:
+
+- `Repository:` shows linked repo context (`not linked` when missing)
+- `Attention:` explains why it needs action now (or confirms `no action needed`)
+- `Last update:` shows recency using friendly wording like `not recorded` when metadata is missing
+- The **Selected Session** panel mirrors the same plain-language fields for the highlighted row
 
 ### Log Viewer Navigation
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -12,7 +12,7 @@ Starting with one repo makes the board much easier to read.
 
 ## 2) What you are looking at
 
-The main screen has an **ATC overview strip**, a **3-column board**, and a **Flight Deck** panel for the selected row.
+The main screen has an **ATC overview strip**, a **3-column board**, and a **Selected Session** panel for the highlighted row.
 
 Columns:
 
@@ -20,25 +20,32 @@ Columns:
 - **Done** = completed sessions
 - **Failed** = sessions that need attention
 
-Each row is:
+Each row is labeled for fast scanning:
 
-`status icon + title`
-`repository • source • last updated`
-`↳ contextual hint (for selected row)`
+`status icon + title (+ badge)`
+`Repository: ...`
+`Attention: ... • Last update: ...`
 
-When a session likely needs your reply, you'll see a `🧑 input needed` badge.
+Attention reasons are explicit:
+
+- `needs your input`
+- `failed`
+- `active but quiet` (running/queued but stale)
+- `no action needed`
 
 Example:
 
 `🟢 Add retry logic`
-`maxbeizer/gh-agent-viz • local • 5m ago`
+`Repository: maxbeizer/gh-agent-viz`
+`Attention: no action needed • Last update: 5m ago`
 
-## 3) Why you may see “Untitled Session” or “unknown”
+## 3) Why you may see “Untitled Session” or “not linked / not recorded”
 
 This usually means older/local session metadata is incomplete.
 
 - `Untitled Session` = session didn’t store a usable summary/title
-- `unknown` = no reliable timestamp/status signal was found
+- `not linked` = repository/branch metadata was unavailable
+- `not recorded` = no reliable timestamp signal was found
 
 To reduce noise:
 

--- a/docs/OPERATOR_GUIDE.md
+++ b/docs/OPERATOR_GUIDE.md
@@ -21,13 +21,19 @@ The board includes:
 
 - **ATC Overview**: total/active/done/failed/session-source counters
 - **Three status columns**: active work lanes
-- **Flight Deck**: selected-session context and recommended actions
+- **Selected Session panel**: plain-language context and recommended actions for the highlighted row
 
 Columns:
 
 - **Running**: active or queued sessions
 - **Done**: completed sessions
 - **Failed**: sessions that need attention
+
+Each card includes explicit labels so triage is immediate:
+
+- `Repository:` shows repo context (`not linked` if missing)
+- `Attention:` explains why action is needed (`needs your input`, `failed`, `active but quiet`, or `no action needed`)
+- `Last update:` shows freshness (`not recorded` when timestamp metadata is missing)
 
 ## 3) Core keys (daily use)
 

--- a/internal/tui/components/taskdetail/taskdetail.go
+++ b/internal/tui/components/taskdetail/taskdetail.go
@@ -2,6 +2,8 @@ package taskdetail
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/maxbeizer/gh-agent-viz/internal/data"
@@ -31,12 +33,12 @@ func (m Model) View() string {
 	}
 
 	details := []string{
-		m.titleStyle.Render(m.session.Title),
+		m.titleStyle.Render(detailTitle(m.session.Title)),
 		"",
 		fmt.Sprintf("Status:     %s %s", m.statusIcon(m.session.Status), m.session.Status),
 		fmt.Sprintf("Source:     %s", m.session.Source),
-		fmt.Sprintf("Repository: %s", m.session.Repository),
-		fmt.Sprintf("Branch:     %s", m.session.Branch),
+		fmt.Sprintf("Repository: %s", detailValue(m.session.Repository, "not linked")),
+		fmt.Sprintf("Branch:     %s", detailValue(m.session.Branch, "not linked")),
 	}
 
 	// Add PR info for agent-task sessions
@@ -48,8 +50,8 @@ func (m Model) View() string {
 	}
 
 	details = append(details,
-		fmt.Sprintf("Created:    %s", m.session.CreatedAt.Format("2006-01-02 15:04:05")),
-		fmt.Sprintf("Updated:    %s", m.session.UpdatedAt.Format("2006-01-02 15:04:05")),
+		fmt.Sprintf("Created:    %s", detailTimestamp(m.session.CreatedAt)),
+		fmt.Sprintf("Updated:    %s", detailTimestamp(m.session.UpdatedAt)),
 		fmt.Sprintf("Session ID: %s", m.session.ID),
 	)
 
@@ -67,4 +69,23 @@ func joinVertical(lines []string) string {
 		result += line + "\n"
 	}
 	return result
+}
+
+func detailValue(value string, fallback string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fallback
+	}
+	return trimmed
+}
+
+func detailTimestamp(ts time.Time) string {
+	if ts.IsZero() {
+		return "not recorded"
+	}
+	return ts.Format("2006-01-02 15:04:05")
+}
+
+func detailTitle(title string) string {
+	return detailValue(title, "Untitled Session")
 }

--- a/internal/tui/components/taskdetail/taskdetail_test.go
+++ b/internal/tui/components/taskdetail/taskdetail_test.go
@@ -1,0 +1,58 @@
+package taskdetail
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/maxbeizer/gh-agent-viz/internal/data"
+)
+
+func TestView_UsesFriendlyFallbacks(t *testing.T) {
+	model := New(
+		lipgloss.NewStyle(),
+		lipgloss.NewStyle(),
+		func(string) string { return "•" },
+	)
+	model.SetTask(&data.Session{
+		ID: "session-1",
+	})
+
+	view := model.View()
+	if !strings.Contains(view, "Untitled Session") {
+		t.Fatalf("expected untitled fallback, got: %s", view)
+	}
+	if !strings.Contains(view, "Repository: not linked") {
+		t.Fatalf("expected repository fallback, got: %s", view)
+	}
+	if !strings.Contains(view, "Branch:     not linked") {
+		t.Fatalf("expected branch fallback, got: %s", view)
+	}
+	if !strings.Contains(view, "Created:    not recorded") || !strings.Contains(view, "Updated:    not recorded") {
+		t.Fatalf("expected timestamp fallback, got: %s", view)
+	}
+}
+
+func TestView_ShowsRecordedTimestamps(t *testing.T) {
+	model := New(
+		lipgloss.NewStyle(),
+		lipgloss.NewStyle(),
+		func(string) string { return "•" },
+	)
+	now := time.Date(2025, time.January, 2, 3, 4, 5, 0, time.UTC)
+	model.SetTask(&data.Session{
+		ID:        "session-2",
+		Title:     "Named Session",
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+
+	view := model.View()
+	if !strings.Contains(view, "Created:    2025-01-02 03:04:05") {
+		t.Fatalf("expected formatted created timestamp, got: %s", view)
+	}
+	if !strings.Contains(view, "Updated:    2025-01-02 03:04:05") {
+		t.Fatalf("expected formatted updated timestamp, got: %s", view)
+	}
+}


### PR DESCRIPTION
## Summary\n- make every session card self-describing with labeled Repository/Attention/Last update semantics\n- surface explicit attention reasons (needs input, failed, active but quiet, no action needed) in row copy\n- rename Flight Deck to Selected Session and replace sentinel placeholders with friendly fallbacks\n- add taskdetail fallback handling/tests and update user docs for the new semantics\n\n## Validation\n- go test ./...\n- make smoke\n\nCloses #27