### PR TITLE
Make action hints contextual to selected session

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An interactive terminal UI for visualizing GitHub Copilot coding agent sessions.
 - 🎨 **Status Indicators** - Color-coded status icons (running, queued, completed, failed)
 - 🧑 **Input Needed Detection** - Highlights sessions that appear blocked waiting for human input
 - 🚦 **Attention Reasons** - Every card includes an explicit `Attention:` reason (`needs your input`, `failed`, `active but quiet`, or `no action needed`)
-- ⚡ **Quick Actions** - Open PRs in browser, refresh data, filter by status
+- ⚡ **Quick Actions** - Contextual hints only show actions available for the highlighted session
 - 🔄 **Resume Sessions** - Jump directly into active Copilot CLI sessions with one keystroke
 - ⌨️ **Vim-style Keys** - j/k navigation, familiar keybindings
 - 🛡️ **Tolerant Parsing** - Gracefully handles malformed session files without crashing
@@ -76,13 +76,15 @@ When enabled, the UI also shows a persistent debug banner with the log path.
 | `k` / `↑` | Move up |
 | `enter` | View task details |
 | `l` | View task logs (remote agent sessions) |
-| `o` | Open PR in browser |
-| `s` | Resume active session |
+| `o` | Open linked PR in browser (only when a PR is available) |
+| `s` | Resume active local session (running/queued/needs-input) |
 | `a` | Toggle attention mode (sessions needing action) |
 | `r` | Refresh task list |
 | `tab` / `shift+tab` | Cycle status filter forward/backward (`all ↔ attention ↔ active ↔ completed ↔ failed`) |
 | `esc` | Go back to task list |
 | `q` | Quit |
+
+Action hints in the footer are contextual: unavailable actions are hidden for the currently highlighted session.
 
 ### Resume Active Sessions
 

--- a/docs/OPERATOR_GUIDE.md
+++ b/docs/OPERATOR_GUIDE.md
@@ -42,8 +42,8 @@ Each card includes explicit labels so triage is immediate:
 | `h` / `←` and `→` | Move between columns |
 | `j` / `k` | Move up/down in a column |
 | `enter` | Open details pane |
-| `l` | Open log view (remote agent-task rows) |
-| `o` | Open PR in browser (agent-task rows) |
+| `l` | Open log view (only shown for remote agent-task rows) |
+| `o` | Open PR in browser (only shown when selected row has a linked PR) |
 | `s` | Resume active **local** Copilot session |
 | `a` | Toggle **attention mode** (sessions needing your action) |
 | `tab` / `shift+tab` | Cycle filter: all ↔ attention ↔ active ↔ completed ↔ failed |
@@ -57,6 +57,8 @@ Each card includes explicit labels so triage is immediate:
 3. Jump to logs (`l`) if something looks off.
 4. Open PR (`o`) for completed remote work.
 5. Resume local active work (`s`) when you want to continue in Copilot CLI.
+
+Footer hints are contextual: if an action is unavailable for the selected row, it is hidden.
 
 ## 5) Recommended config
 

--- a/internal/tui/components/tasklist/tasklist.go
+++ b/internal/tui/components/tasklist/tasklist.go
@@ -149,7 +149,10 @@ func (m Model) renderFlightDeck() string {
 
 	actions := []string{"enter details"}
 	if selected.Source == data.SourceAgentTask {
-		actions = append(actions, "l logs", "o open PR")
+		actions = append(actions, "l logs")
+		if sessionHasLinkedPR(*selected) {
+			actions = append(actions, "o open PR")
+		}
 	}
 	if selected.Source == data.SourceLocalCopilot && isActiveStatus(selected.Status) && selected.ID != "" {
 		actions = append(actions, "s resume")
@@ -496,6 +499,16 @@ func panelBranch(session data.Session) string {
 		return "not linked"
 	}
 	return branch
+}
+
+func sessionHasLinkedPR(session data.Session) bool {
+	if session.Source != data.SourceAgentTask {
+		return false
+	}
+	if strings.TrimSpace(session.PRURL) != "" {
+		return true
+	}
+	return session.PRNumber > 0 && strings.TrimSpace(session.Repository) != ""
 }
 
 func attentionReason(session data.Session) string {


### PR DESCRIPTION
## Summary
- make footer hints capability-aware so unavailable actions are hidden for the selected row
- only advertise `o open PR` when the selected remote session has a linked PR reference
- add UI/tasklist tests for contextual actions and update operator docs

## Validation
- go test ./...
- make smoke

Closes #29
