### PR TITLE
Improve board readability and action clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ An interactive terminal UI for visualizing GitHub Copilot coding agent sessions.
 ## Features
 
 - 📊 **Interactive TUI** - Browse agent sessions with keyboard navigation
-- 🛩️ **ATC Overview + Selected Session panel** - Live counters plus plain-language details/actions for the highlighted row
+- 📌 **Sessions at a Glance + Session Summary panel** - Fast status counts plus plain-language details/actions for the highlighted row
 - 🔍 **Task Details** - View comprehensive task metadata (status, repo, branch, PR links)
 - 📝 **Log Viewer** - Scrollable, searchable agent task logs
 - 💻 **Local Sessions** - Automatically ingests local Copilot CLI sessions from `~/.copilot/session-state/`
 - 🎨 **Status Indicators** - Color-coded status icons (running, queued, completed, failed)
 - 🧑 **Input Needed Detection** - Highlights sessions that appear blocked waiting for human input
-- 🚦 **Attention Reasons** - Every card includes an explicit `Attention:` reason (`needs your input`, `failed`, `active but quiet`, or `no action needed`)
+- 🚦 **Action Reasons** - Every card includes an explicit `Needs your action:` reason (`waiting on your input`, `run failed`, `running but quiet`, or `no action needed`)
 - ⚡ **Quick Actions** - Contextual hints only show actions available for the highlighted session
 - 🔄 **Resume Sessions** - Jump directly into active Copilot CLI sessions with one keystroke
 - ⌨️ **Vim-style Keys** - j/k navigation, familiar keybindings
@@ -78,9 +78,9 @@ When enabled, the UI also shows a persistent debug banner with the log path.
 | `l` | View task logs (remote agent sessions) |
 | `o` | Open linked PR in browser (only when a PR is available) |
 | `s` | Resume active local session (running/queued/needs-input) |
-| `a` | Toggle attention mode (sessions needing action) |
+| `a` | Toggle needs-action view (sessions needing action) |
 | `r` | Refresh task list |
-| `tab` / `shift+tab` | Cycle status filter forward/backward (`all ↔ attention ↔ active ↔ completed ↔ failed`) |
+| `tab` / `shift+tab` | Cycle status filter forward/backward (`all ↔ needs action ↔ running ↔ done ↔ failed`) |
 | `esc` | Go back to task list |
 | `q` | Quit |
 
@@ -96,10 +96,10 @@ Press `s` on any active **local Copilot CLI session** (status: `running` or `que
 
 Each session card is intentionally labeled for quick triage:
 
-- `Repository:` shows linked repo context (`not linked` when missing)
-- `Attention:` explains why it needs action now (or confirms `no action needed`)
+- `Repository:` shows linked repo context (`not available` when missing)
+- `Needs your action:` explains why it needs action now (or confirms `no action needed`)
 - `Last update:` shows recency using friendly wording like `not recorded` when metadata is missing
-- The **Selected Session** panel mirrors the same plain-language fields for the highlighted row
+- The **Session Summary** panel mirrors the same plain-language fields for the highlighted row
 
 ### Log Viewer Navigation
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -12,7 +12,7 @@ Starting with one repo makes the board much easier to read.
 
 ## 2) What you are looking at
 
-The main screen has an **ATC overview strip**, a **3-column board**, and a **Selected Session** panel for the highlighted row.
+The main screen has a **Sessions at a Glance strip**, a **3-column board**, and a **Session Summary** panel for the highlighted row.
 
 Columns:
 
@@ -24,27 +24,27 @@ Each row is labeled for fast scanning:
 
 `status icon + title (+ badge)`
 `Repository: ...`
-`Attention: ... • Last update: ...`
+`Needs your action: ... • Last update: ...`
 
 Attention reasons are explicit:
 
-- `needs your input`
-- `failed`
-- `active but quiet` (running/queued but stale)
+- `waiting on your input`
+- `run failed`
+- `running but quiet` (running/queued but stale)
 - `no action needed`
 
 Example:
 
 `🟢 Add retry logic`
 `Repository: maxbeizer/gh-agent-viz`
-`Attention: no action needed • Last update: 5m ago`
+`Needs your action: no action needed • Last update: 5m ago`
 
-## 3) Why you may see “Untitled Session” or “not linked / not recorded”
+## 3) Why you may see “Untitled Session” or “not available / not recorded”
 
 This usually means older/local session metadata is incomplete.
 
 - `Untitled Session` = session didn’t store a usable summary/title
-- `not linked` = repository/branch metadata was unavailable
+- `not available` = repository/branch metadata was unavailable
 - `not recorded` = no reliable timestamp signal was found
 
 To reduce noise:
@@ -62,12 +62,12 @@ To reduce noise:
 - `o`: open PR (remote agent rows)
 - `s`: resume active local session
 - `tab` / `shift+tab`: change filter forward/backward
-- `a`: toggle attention mode
+- `a`: toggle needs-action view
 - `q`: quit
 
 ## 5) First useful workflow
 
-1. Filter to `attention` (`a`)
+1. Filter to needs-action view (`a`)
 2. Open a row (`enter`)
 3. Check logs (`l`) if needed
 4. Open PR (`o`) or resume (`s`) depending on row source

--- a/docs/OPERATOR_GUIDE.md
+++ b/docs/OPERATOR_GUIDE.md
@@ -19,9 +19,9 @@ gh agent-viz --debug
 
 The board includes:
 
-- **ATC Overview**: total/active/done/failed/session-source counters
+- **Sessions at a Glance**: total/running/done/failed plus `needs action` count
 - **Three status columns**: active work lanes
-- **Selected Session panel**: plain-language context and recommended actions for the highlighted row
+- **Session Summary panel**: plain-language context and recommended actions for the highlighted row
 
 Columns:
 
@@ -31,8 +31,8 @@ Columns:
 
 Each card includes explicit labels so triage is immediate:
 
-- `Repository:` shows repo context (`not linked` if missing)
-- `Attention:` explains why action is needed (`needs your input`, `failed`, `active but quiet`, or `no action needed`)
+- `Repository:` shows repo context (`not available` if missing)
+- `Needs your action:` explains why action is needed (`waiting on your input`, `run failed`, `running but quiet`, or `no action needed`)
 - `Last update:` shows freshness (`not recorded` when timestamp metadata is missing)
 
 ## 3) Core keys (daily use)
@@ -45,14 +45,14 @@ Each card includes explicit labels so triage is immediate:
 | `l` | Open log view (only shown for remote agent-task rows) |
 | `o` | Open PR in browser (only shown when selected row has a linked PR) |
 | `s` | Resume active **local** Copilot session |
-| `a` | Toggle **attention mode** (sessions needing your action) |
-| `tab` / `shift+tab` | Cycle filter: all ↔ attention ↔ active ↔ completed ↔ failed |
+| `a` | Toggle **needs-action view** (sessions needing your action) |
+| `tab` / `shift+tab` | Cycle filter: all ↔ needs action ↔ running ↔ done ↔ failed |
 | `r` | Refresh now |
 | `q` | Quit |
 
 ## 4) Typical workflow
 
-1. Start in **attention mode** (`a`) to triage what needs you now.
+1. Start in **needs-action view** (`a`) to triage what needs you now.
 2. Open details (`enter`) for a session you care about.
 3. Jump to logs (`l`) if something looks off.
 4. Open PR (`o`) for completed remote work.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -15,7 +15,7 @@ gh agent-viz --help
 Try:
 
 1. Press `r` to refresh.
-2. Press `a` to check attention mode, then `tab` to cycle other filters in case rows are hidden.
+2. Press `a` to check needs-action view, then `tab` to cycle other filters in case rows are hidden.
 3. Run with repo scope:
    ```bash
    gh agent-viz --repo owner/repo

--- a/internal/tui/components/header/header.go
+++ b/internal/tui/components/header/header.go
@@ -31,9 +31,22 @@ func (m Model) View() string {
 	title := m.titleStyle.Render(m.title)
 	filterText := ""
 	if m.filter != nil && *m.filter != "" {
-		filterText = m.filterStyle.Render("Filter: " + *m.filter)
+		filterText = m.filterStyle.Render("Filter: " + filterLabel(*m.filter))
 	}
 
 	header := lipgloss.JoinHorizontal(lipgloss.Top, title, filterText)
 	return header + "\n"
+}
+
+func filterLabel(filter string) string {
+	switch filter {
+	case "attention":
+		return "needs action"
+	case "active":
+		return "running"
+	case "completed":
+		return "done"
+	default:
+		return filter
+	}
 }

--- a/internal/tui/components/header/header_test.go
+++ b/internal/tui/components/header/header_test.go
@@ -65,8 +65,8 @@ func TestView_WithFilter(t *testing.T) {
 	if !strings.Contains(view, "Filter:") {
 		t.Error("expected view to contain 'Filter:' label")
 	}
-	if !strings.Contains(view, filter) {
-		t.Errorf("expected view to contain filter '%s'", filter)
+	if !strings.Contains(view, "done") {
+		t.Errorf("expected view to contain user-friendly filter label, got: %s", view)
 	}
 }
 

--- a/internal/tui/components/taskdetail/taskdetail.go
+++ b/internal/tui/components/taskdetail/taskdetail.go
@@ -37,8 +37,8 @@ func (m Model) View() string {
 		"",
 		fmt.Sprintf("Status:     %s %s", m.statusIcon(m.session.Status), m.session.Status),
 		fmt.Sprintf("Source:     %s", m.session.Source),
-		fmt.Sprintf("Repository: %s", detailValue(m.session.Repository, "not linked")),
-		fmt.Sprintf("Branch:     %s", detailValue(m.session.Branch, "not linked")),
+		fmt.Sprintf("Repository: %s", detailValue(m.session.Repository, "not available")),
+		fmt.Sprintf("Branch:     %s", detailValue(m.session.Branch, "not available")),
 	}
 
 	// Add PR info for agent-task sessions

--- a/internal/tui/components/taskdetail/taskdetail_test.go
+++ b/internal/tui/components/taskdetail/taskdetail_test.go
@@ -23,10 +23,10 @@ func TestView_UsesFriendlyFallbacks(t *testing.T) {
 	if !strings.Contains(view, "Untitled Session") {
 		t.Fatalf("expected untitled fallback, got: %s", view)
 	}
-	if !strings.Contains(view, "Repository: not linked") {
+	if !strings.Contains(view, "Repository: not available") {
 		t.Fatalf("expected repository fallback, got: %s", view)
 	}
-	if !strings.Contains(view, "Branch:     not linked") {
+	if !strings.Contains(view, "Branch:     not available") {
 		t.Fatalf("expected branch fallback, got: %s", view)
 	}
 	if !strings.Contains(view, "Created:    not recorded") || !strings.Contains(view, "Updated:    not recorded") {

--- a/internal/tui/components/tasklist/tasklist_test.go
+++ b/internal/tui/components/tasklist/tasklist_test.go
@@ -106,12 +106,12 @@ func TestViewShowsKanbanColumns(t *testing.T) {
 
 func TestViewEmptyAndLoadingStates(t *testing.T) {
 	model := newModel()
-	if got := model.View(); !strings.Contains(got, "The sky is clear") {
+	if got := model.View(); !strings.Contains(got, "No sessions to show yet") {
 		t.Fatalf("expected empty state, got: %s", got)
 	}
 
 	model.loading = true
-	if got := model.View(); !strings.Contains(got, "Warming up the radar") {
+	if got := model.View(); !strings.Contains(got, "Loading sessions") {
 		t.Fatalf("expected loading state, got: %s", got)
 	}
 }
@@ -167,11 +167,12 @@ func TestView_ShowsSourceBadge(t *testing.T) {
 			UpdatedAt:  time.Now(),
 		},
 	}
+	model.SetSize(140, 36)
 	model.SetTasks(tasks)
 
 	view := model.View()
-	if !strings.Contains(view, "agent") {
-		t.Error("expected view to contain session source")
+	if !strings.Contains(view, "Source: agent") {
+		t.Error("expected session summary to contain source label")
 	}
 }
 
@@ -207,10 +208,10 @@ func TestView_ImprovedEmptyState(t *testing.T) {
 	)
 
 	view := model.View()
-	if !strings.Contains(view, "The sky is clear") {
+	if !strings.Contains(view, "No sessions to show yet") {
 		t.Error("expected improved empty state message")
 	}
-	if !strings.Contains(view, "Press 'r' to scan again") {
+	if !strings.Contains(view, "Press 'r' to refresh") {
 		t.Error("expected empty state to include helpful hints")
 	}
 }
@@ -245,7 +246,7 @@ func TestView_NarrowModeShowsSingleLaneHint(t *testing.T) {
 	})
 
 	view := model.View()
-	if !strings.Contains(view, "NARROW MODE") {
+	if !strings.Contains(view, "COMPACT VIEW") {
 		t.Fatalf("expected narrow mode hint, got: %s", view)
 	}
 }
@@ -258,7 +259,7 @@ func TestView_VeryNarrowWidthUsesCompactRows(t *testing.T) {
 	})
 
 	view := model.View()
-	if !strings.Contains(view, "NARROW MODE") {
+	if !strings.Contains(view, "COMPACT VIEW") {
 		t.Fatalf("expected narrow mode hint, got: %s", view)
 	}
 	if strings.Contains(view, "• just now") {
@@ -274,7 +275,7 @@ func TestView_VeryShortHeightHidesFlightDeck(t *testing.T) {
 	})
 
 	view := model.View()
-	if strings.Contains(view, "SELECTED SESSION") || strings.Contains(view, "Selected Session") {
+	if strings.Contains(view, "SESSION SUMMARY") || strings.Contains(view, "Session Summary") {
 		t.Fatalf("expected no selected session panel in very short layout, got: %s", view)
 	}
 }
@@ -287,7 +288,7 @@ func TestView_MediumHeightUsesCompactFlightDeck(t *testing.T) {
 	})
 
 	view := model.View()
-	if !strings.Contains(view, "Selected Session •") {
+	if !strings.Contains(view, "Session Summary •") {
 		t.Fatalf("expected compact selected session panel in medium layout, got: %s", view)
 	}
 }
@@ -324,7 +325,7 @@ func TestView_ShowsAttentionChip(t *testing.T) {
 	})
 
 	view := model.View()
-	if !strings.Contains(view, "attention 1") {
+	if !strings.Contains(view, "needs action 1") {
 		t.Fatalf("expected attention chip, got: %s", view)
 	}
 }
@@ -358,10 +359,10 @@ func TestView_CardShowsAttentionReason(t *testing.T) {
 	})
 
 	view := model.View()
-	if !strings.Contains(view, "Attention: needs your input") {
+	if !strings.Contains(view, "Needs your action: waiting on your input") {
 		t.Fatalf("expected explicit input-needed reason, got: %s", view)
 	}
-	if !strings.Contains(view, "Attention: active but quiet") {
+	if !strings.Contains(view, "Needs your action: running but quiet") {
 		t.Fatalf("expected explicit quiet-active reason, got: %s", view)
 	}
 }
@@ -379,13 +380,13 @@ func TestView_SelectedSessionUsesFriendlyFallbacks(t *testing.T) {
 	})
 
 	view := model.View()
-	if !strings.Contains(view, "SELECTED SESSION") {
+	if !strings.Contains(view, "SESSION SUMMARY") {
 		t.Fatalf("expected selected session heading, got: %s", view)
 	}
-	if !strings.Contains(view, "Repository: not linked") {
+	if !strings.Contains(view, "Repository: not available") {
 		t.Fatalf("expected friendly repository fallback, got: %s", view)
 	}
-	if !strings.Contains(view, "Branch: not linked") {
+	if !strings.Contains(view, "Branch: not available") {
 		t.Fatalf("expected friendly branch fallback, got: %s", view)
 	}
 	if !strings.Contains(view, "Last update: not recorded") {
@@ -411,7 +412,7 @@ func TestView_SelectedSessionOmitsOpenPRActionWhenNoPRLinked(t *testing.T) {
 	})
 
 	view := model.View()
-	if !strings.Contains(view, "Actions: enter details • l logs") {
+	if !strings.Contains(view, "Available actions: enter details • l logs") {
 		t.Fatalf("expected selected-session actions to include logs, got: %s", view)
 	}
 	if strings.Contains(view, "o open PR") {

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -60,7 +60,7 @@ func NewKeybindings() Keybindings {
 		),
 		FocusAttention: key.NewBinding(
 			key.WithKeys("a"),
-			key.WithHelp("a", "attention mode"),
+			key.WithHelp("a", "needs-action view"),
 		),
 		ExitApp: key.NewBinding(
 			key.WithKeys("q", "ctrl+c"),

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -158,7 +158,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // View renders the TUI
 func (m Model) View() string {
 	if !m.ready {
-		return "Spinning up ATC tower..."
+		return "Loading board..."
 	}
 
 	// Update footer hints based on current context

--- a/internal/tui/ui_test.go
+++ b/internal/tui/ui_test.go
@@ -231,7 +231,7 @@ func TestHandleListKeys_LocalSessionLogShowsHelpfulError(t *testing.T) {
 func TestView_NotReadyShowsWhimsicalStartupText(t *testing.T) {
 	m := NewModel("", false)
 	view := m.View()
-	if view != "Spinning up ATC tower..." {
+	if view != "Loading board..." {
 		t.Fatalf("expected startup text, got %q", view)
 	}
 }


### PR DESCRIPTION
## Summary
- replace ATC-heavy board copy with plain-language labels (`SESSIONS AT A GLANCE`, `SESSION SUMMARY`, `Needs your action`)
- reduce overview noise by collapsing low-value counters and emphasizing the needs-action signal
- replace ambiguous fallback wording (`not linked`) with clearer phrasing (`not available`)
- update tests and operator docs/getting-started/readme terminology to match shipped behavior

## Validation
- `go test ./...`
- `make smoke`

Closes #31
