### PR TITLE
UX redesign: focused pane driven by filter tabs

### DIFF
--- a/internal/tui/components/header/header.go
+++ b/internal/tui/components/header/header.go
@@ -1,40 +1,82 @@
 package header
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/charmbracelet/lipgloss"
 )
+
+// FilterCounts holds per-filter session counts for the tab bar
+type FilterCounts struct {
+	All       int
+	Attention int
+	Active    int
+	Completed int
+	Failed    int
+}
 
 // Model represents the header component state
 type Model struct {
 	titleStyle  lipgloss.Style
-	filterStyle lipgloss.Style
+	tabActive   lipgloss.Style
+	tabInactive lipgloss.Style
+	tabCount    lipgloss.Style
 	title       string
 	filter      *string
+	counts      FilterCounts
 }
 
 // New creates a new header model
-func New(titleStyle lipgloss.Style, title string, filter *string) Model {
-	filterStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("241")).
-		Padding(0, 2)
-
+func New(titleStyle, tabActive, tabInactive, tabCount lipgloss.Style, title string, filter *string) Model {
 	return Model{
 		titleStyle:  titleStyle,
-		filterStyle: filterStyle,
+		tabActive:   tabActive,
+		tabInactive: tabInactive,
+		tabCount:    tabCount,
 		title:       title,
 		filter:      filter,
 	}
 }
 
-// View renders the header
+// SetCounts updates the filter counts displayed in tab badges
+func (m *Model) SetCounts(counts FilterCounts) {
+	m.counts = counts
+}
+
+// View renders the header as a tab bar
 func (m Model) View() string {
 	title := m.titleStyle.Render(m.title)
-	filterText := ""
+
+	activeFilter := "all"
 	if m.filter != nil && *m.filter != "" {
-		filterText = m.filterStyle.Render("Filter: " + filterLabel(*m.filter))
+		activeFilter = *m.filter
 	}
 
-	header := lipgloss.JoinHorizontal(lipgloss.Top, title, filterText)
+	tabs := []struct {
+		key   string
+		label string
+		count int
+	}{
+		{"all", "ALL", m.counts.All},
+		{"attention", "ACTION", m.counts.Attention},
+		{"active", "RUNNING", m.counts.Active},
+		{"completed", "DONE", m.counts.Completed},
+		{"failed", "FAILED", m.counts.Failed},
+	}
+
+	renderedTabs := make([]string, 0, len(tabs))
+	for _, tab := range tabs {
+		label := fmt.Sprintf("%s %s", tab.label, m.tabCount.Render(fmt.Sprintf("(%d)", tab.count)))
+		if tab.key == activeFilter {
+			renderedTabs = append(renderedTabs, m.tabActive.Render(label))
+		} else {
+			renderedTabs = append(renderedTabs, m.tabInactive.Render(label))
+		}
+	}
+
+	tabBar := strings.Join(renderedTabs, "")
+	header := lipgloss.JoinHorizontal(lipgloss.Center, title, "  ", tabBar)
 	return header + "\n"
 }
 

--- a/internal/tui/components/header/header_test.go
+++ b/internal/tui/components/header/header_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+func newTestModel(title string, filter *string) Model {
+	s := lipgloss.NewStyle()
+	return New(s, s, s, s, title, filter)
+}
+
 func TestNew(t *testing.T) {
-	titleStyle := lipgloss.NewStyle().Bold(true)
 	title := "Agent Task Viewer"
 	filter := "running"
 
-	model := New(titleStyle, title, &filter)
+	model := newTestModel(title, &filter)
 
 	if model.title != title {
 		t.Errorf("expected title '%s', got '%s'", title, model.title)
@@ -26,10 +30,9 @@ func TestNew(t *testing.T) {
 }
 
 func TestNew_NilFilter(t *testing.T) {
-	titleStyle := lipgloss.NewStyle().Bold(true)
 	title := "Agent Task Viewer"
 
-	model := New(titleStyle, title, nil)
+	model := newTestModel(title, nil)
 
 	if model.title != title {
 		t.Errorf("expected title '%s', got '%s'", title, model.title)
@@ -40,10 +43,9 @@ func TestNew_NilFilter(t *testing.T) {
 }
 
 func TestView_RendersTitle(t *testing.T) {
-	titleStyle := lipgloss.NewStyle()
 	title := "My Application"
 
-	model := New(titleStyle, title, nil)
+	model := newTestModel(title, nil)
 	view := model.View()
 
 	if !strings.Contains(view, title) {
@@ -52,61 +54,42 @@ func TestView_RendersTitle(t *testing.T) {
 }
 
 func TestView_WithFilter(t *testing.T) {
-	titleStyle := lipgloss.NewStyle()
 	title := "Tasks"
 	filter := "completed"
 
-	model := New(titleStyle, title, &filter)
+	model := newTestModel(title, &filter)
+	model.SetCounts(FilterCounts{All: 5, Completed: 2})
 	view := model.View()
 
 	if !strings.Contains(view, title) {
 		t.Errorf("expected view to contain title '%s'", title)
 	}
-	if !strings.Contains(view, "Filter:") {
-		t.Error("expected view to contain 'Filter:' label")
-	}
-	if !strings.Contains(view, "done") {
-		t.Errorf("expected view to contain user-friendly filter label, got: %s", view)
+	// Active tab should be highlighted
+	if !strings.Contains(view, "DONE") {
+		t.Errorf("expected view to contain DONE tab for completed filter, got: %s", view)
 	}
 }
 
-func TestView_WithEmptyFilter(t *testing.T) {
-	titleStyle := lipgloss.NewStyle()
+func TestView_WithTabCounts(t *testing.T) {
 	title := "Tasks"
-	filter := ""
+	filter := "all"
 
-	model := New(titleStyle, title, &filter)
+	model := newTestModel(title, &filter)
+	model.SetCounts(FilterCounts{All: 10, Attention: 3, Active: 5, Completed: 4, Failed: 1})
 	view := model.View()
 
-	if !strings.Contains(view, title) {
-		t.Errorf("expected view to contain title '%s'", title)
+	if !strings.Contains(view, "(10)") {
+		t.Errorf("expected ALL count of 10, got: %s", view)
 	}
-	// Empty filter should not show the filter label
-	if strings.Contains(view, "Filter:") {
-		t.Error("did not expect view to contain 'Filter:' label when filter is empty")
-	}
-}
-
-func TestView_WithNilFilter(t *testing.T) {
-	titleStyle := lipgloss.NewStyle()
-	title := "Tasks"
-
-	model := New(titleStyle, title, nil)
-	view := model.View()
-
-	if !strings.Contains(view, title) {
-		t.Errorf("expected view to contain title '%s'", title)
-	}
-	if strings.Contains(view, "Filter:") {
-		t.Error("did not expect view to contain 'Filter:' label when filter is nil")
+	if !strings.Contains(view, "(3)") {
+		t.Errorf("expected ACTION count of 3, got: %s", view)
 	}
 }
 
 func TestView_EndsWithNewline(t *testing.T) {
-	titleStyle := lipgloss.NewStyle()
 	title := "Tasks"
 
-	model := New(titleStyle, title, nil)
+	model := newTestModel(title, nil)
 	view := model.View()
 
 	if !strings.HasSuffix(view, "\n") {

--- a/internal/tui/context.go
+++ b/internal/tui/context.go
@@ -2,6 +2,15 @@ package tui
 
 import "github.com/maxbeizer/gh-agent-viz/internal/config"
 
+// FilterCounts holds the session count for each filter state
+type FilterCounts struct {
+	All       int
+	Attention int
+	Active    int
+	Completed int
+	Failed    int
+}
+
 // ProgramContext holds shared state and configuration for the TUI
 type ProgramContext struct {
 	Config       *config.Config
@@ -10,6 +19,7 @@ type ProgramContext struct {
 	Error        error
 	Debug        bool
 	StatusFilter string // "all", "attention", "active", "completed", "failed"
+	Counts       FilterCounts
 }
 
 // NewProgramContext initializes a new program context

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -4,8 +4,6 @@ import "github.com/charmbracelet/bubbles/key"
 
 // Keybindings holds all key bindings for the application
 type Keybindings struct {
-	MoveLeft       key.Binding
-	MoveRight      key.Binding
 	MoveUp         key.Binding
 	MoveDown       key.Binding
 	SelectTask     key.Binding
@@ -22,45 +20,37 @@ type Keybindings struct {
 // NewKeybindings creates the default key bindings for the TUI
 func NewKeybindings() Keybindings {
 	return Keybindings{
-		MoveLeft: key.NewBinding(
-			key.WithKeys("h", "left"),
-			key.WithHelp("h/←", "move column left"),
-		),
-		MoveRight: key.NewBinding(
-			key.WithKeys("right"),
-			key.WithHelp("→", "move column right"),
-		),
 		MoveUp: key.NewBinding(
 			key.WithKeys("k", "up"),
-			key.WithHelp("k/↑", "navigate up"),
+			key.WithHelp("k/↑", "up"),
 		),
 		MoveDown: key.NewBinding(
 			key.WithKeys("j", "down"),
-			key.WithHelp("j/↓", "navigate down"),
+			key.WithHelp("j/↓", "down"),
 		),
 		SelectTask: key.NewBinding(
 			key.WithKeys("enter"),
-			key.WithHelp("enter", "show task details"),
+			key.WithHelp("enter", "details"),
 		),
 		ShowLogs: key.NewBinding(
 			key.WithKeys("l"),
-			key.WithHelp("l", "show task logs"),
+			key.WithHelp("l", "logs"),
 		),
 		OpenInBrowser: key.NewBinding(
 			key.WithKeys("o"),
-			key.WithHelp("o", "open PR URL"),
+			key.WithHelp("o", "open PR"),
 		),
 		ResumeSession: key.NewBinding(
 			key.WithKeys("s"),
-			key.WithHelp("s", "resume session"),
+			key.WithHelp("s", "resume"),
 		),
 		RefreshData: key.NewBinding(
 			key.WithKeys("r"),
-			key.WithHelp("r", "refresh tasks"),
+			key.WithHelp("r", "refresh"),
 		),
 		FocusAttention: key.NewBinding(
 			key.WithKeys("a"),
-			key.WithHelp("a", "needs-action view"),
+			key.WithHelp("a", "action view"),
 		),
 		ExitApp: key.NewBinding(
 			key.WithKeys("q", "ctrl+c"),
@@ -68,11 +58,11 @@ func NewKeybindings() Keybindings {
 		),
 		ToggleFilter: key.NewBinding(
 			key.WithKeys("tab", "shift+tab"),
-			key.WithHelp("tab/shift+tab", "switch status filter"),
+			key.WithHelp("tab", "filter"),
 		),
 		NavigateBack: key.NewBinding(
 			key.WithKeys("esc"),
-			key.WithHelp("esc", "return to list"),
+			key.WithHelp("esc", "back"),
 		),
 	}
 }

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -14,6 +14,15 @@ type Theme struct {
 	Border           lipgloss.Style
 	Title            lipgloss.Style
 	Footer           lipgloss.Style
+	// Tab bar styles
+	TabActive   lipgloss.Style
+	TabInactive lipgloss.Style
+	TabCount    lipgloss.Style
+	// Focus area styles
+	FocusBorder   lipgloss.Style
+	RowGutter     lipgloss.Style
+	RowGutterSel  lipgloss.Style
+	SectionHeader lipgloss.Style
 }
 
 // NewTheme creates a default theme
@@ -43,6 +52,34 @@ func NewTheme() *Theme {
 			Padding(0, 1),
 		Footer: lipgloss.NewStyle().
 			Foreground(lipgloss.Color("241")).
+			Padding(0, 1),
+		// Active tab: bold with magenta accent background
+		TabActive: lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("15")).
+			Background(lipgloss.Color("99")).
+			Padding(0, 2),
+		// Inactive tab: subdued
+		TabInactive: lipgloss.NewStyle().
+			Foreground(lipgloss.Color("245")).
+			Padding(0, 2),
+		// Count badge inside tabs
+		TabCount: lipgloss.NewStyle().
+			Foreground(lipgloss.Color("241")),
+		// Focus area border
+		FocusBorder: lipgloss.NewStyle().
+			BorderStyle(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("63")),
+		// Left gutter indicator for selected row
+		RowGutter: lipgloss.NewStyle().
+			Foreground(lipgloss.Color("238")),
+		RowGutterSel: lipgloss.NewStyle().
+			Foreground(lipgloss.Color("99")).
+			Bold(true),
+		// Section headers within the focus area
+		SectionHeader: lipgloss.NewStyle().
+			Foreground(lipgloss.Color("63")).
+			Bold(true).
 			Padding(0, 1),
 	}
 }

--- a/internal/tui/ui_test.go
+++ b/internal/tui/ui_test.go
@@ -228,10 +228,10 @@ func TestHandleListKeys_LocalSessionLogShowsHelpfulError(t *testing.T) {
 	}
 }
 
-func TestView_NotReadyShowsWhimsicalStartupText(t *testing.T) {
+func TestView_NotReadyShowsStartupText(t *testing.T) {
 	m := NewModel("", false)
 	view := m.View()
-	if view != "Loading board..." {
+	if view != "Loading sessions..." {
 		t.Fatalf("expected startup text, got %q", view)
 	}
 }
@@ -250,13 +250,13 @@ func TestUpdateFooterHints_LocalSessionShowsOnlyAvailableActions(t *testing.T) {
 
 	m.updateFooterHints()
 	footerView := m.footer.View()
-	if !strings.Contains(footerView, "resume session") {
+	if !strings.Contains(footerView, "resume") {
 		t.Fatalf("expected resume hint for resumable local session, got: %s", footerView)
 	}
-	if strings.Contains(footerView, "show task logs") {
+	if strings.Contains(footerView, "logs") {
 		t.Fatalf("expected logs hint to be hidden for local session, got: %s", footerView)
 	}
-	if strings.Contains(footerView, "open PR URL") {
+	if strings.Contains(footerView, "open PR") {
 		t.Fatalf("expected open PR hint to be hidden for local session, got: %s", footerView)
 	}
 }
@@ -276,10 +276,10 @@ func TestUpdateFooterHints_AgentSessionWithoutPRHidesOpenPRHint(t *testing.T) {
 
 	m.updateFooterHints()
 	footerView := m.footer.View()
-	if !strings.Contains(footerView, "show task logs") {
+	if !strings.Contains(footerView, "logs") {
 		t.Fatalf("expected logs hint for agent session, got: %s", footerView)
 	}
-	if strings.Contains(footerView, "open PR URL") {
+	if strings.Contains(footerView, "open PR") {
 		t.Fatalf("expected open PR hint to be hidden when PR is not linked, got: %s", footerView)
 	}
 }


### PR DESCRIPTION
## Summary
Replaces the 3-column kanban board with a single focused session list driven by interactive filter tabs. Addresses the core UX feedback from issue #33: too much low-value content consuming screen real estate.

## What changed

### Tab bar with live counts
The header is now an interactive filter tab bar showing `ALL (12)  ACTION (3)  RUNNING (5)  DONE (4)  FAILED (1)`. Tab/Shift+Tab cycles through filters; the active tab is highlighted with a magenta accent. Counts are computed across **all** sessions before filtering, so you always have situational awareness.

### Single focused list
No more columns. One scrollable list shows sessions matching the active filter. A left-gutter `▎` indicator marks the selected row. Below the list, an inline detail panel shows full metadata for the selected session.

### Simplified navigation
- `j/k` or `↑/↓` — navigate the list
- `tab/shift+tab` — cycle filters (this is now the primary interaction)
- `enter` — show session details
- Column nav (`h/←/→`) removed — no columns to navigate

### Visual identity
Deliberately diverges from gh-dash's aesthetic:
- Magenta/purple tab accents with UPPERCASE labels
- Left-gutter bar indicator (not full-row inversion)
- Emoji status icons as primary visual markers
- Compact inline detail panel (not separate panes)

### Numbers
- `tasklist.go`: ~710 LOC → ~480 LOC (net -191 lines across all files)
- All 37 tests pass

## Testing
```
go test ./... -count=1
```

Refs #35, #36