### PR TITLE
Sort by recency, dismiss sessions with x

### DIFF
--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -10,6 +10,7 @@ type Keybindings struct {
 	ShowLogs       key.Binding
 	OpenInBrowser  key.Binding
 	ResumeSession  key.Binding
+	DismissSession key.Binding
 	RefreshData    key.Binding
 	FocusAttention key.Binding
 	ExitApp        key.Binding
@@ -43,6 +44,10 @@ func NewKeybindings() Keybindings {
 		ResumeSession: key.NewBinding(
 			key.WithKeys("s"),
 			key.WithHelp("s", "resume"),
+		),
+		DismissSession: key.NewBinding(
+			key.WithKeys("x"),
+			key.WithHelp("x", "dismiss"),
 		),
 		RefreshData: key.NewBinding(
 			key.WithKeys("r"),

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -257,6 +257,8 @@ func (m Model) handleListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if session != nil {
 			return m, m.resumeSession(session)
 		}
+	case "x":
+		m.taskList.DismissSelected()
 	case "r":
 		return m, m.fetchTasks
 	case "a":
@@ -534,6 +536,9 @@ func (m *Model) updateFooterHints() {
 		}
 		if canResumeLocalSession(selected) {
 			hints = append(hints, m.keys.ResumeSession)
+		}
+		if selected != nil {
+			hints = append(hints, m.keys.DismissSession)
 		}
 		hints = append(hints, m.keys.ToggleFilter, m.keys.FocusAttention, m.keys.RefreshData, m.keys.ExitApp)
 		m.footer.SetHints(hints)


### PR DESCRIPTION
Two fixes for list usability:

**Recency-first sort**: Sessions now sort by most recent update time, not by status priority. Month-old failures no longer float above today's running sessions. Quiet duplicates still sink to the bottom.

**Dismiss with `x`**: Press `x` to hide any session you don't care about. Dismissed sessions stay hidden across tab switches and auto-refreshes (in-memory, resets on restart). Footer shows the hint when a session is selected.