### PR TITLE
fix: make 'a' key cycle filters and reorder tabs with ALL last

### DIFF
--- a/internal/tui/components/header/header.go
+++ b/internal/tui/components/header/header.go
@@ -48,7 +48,7 @@ func (m *Model) SetCounts(counts FilterCounts) {
 func (m Model) View() string {
 	title := m.titleStyle.Render(m.title)
 
-	activeFilter := "all"
+	activeFilter := "attention"
 	if m.filter != nil && *m.filter != "" {
 		activeFilter = *m.filter
 	}
@@ -58,11 +58,11 @@ func (m Model) View() string {
 		label string
 		count int
 	}{
-		{"all", "ALL", m.counts.All},
 		{"attention", "ACTION", m.counts.Attention},
 		{"active", "RUNNING", m.counts.Active},
 		{"completed", "DONE", m.counts.Completed},
 		{"failed", "FAILED", m.counts.Failed},
+		{"all", "ALL", m.counts.All},
 	}
 
 	renderedTabs := make([]string, 0, len(tabs))

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -263,11 +263,7 @@ func (m Model) handleListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		return m, m.fetchTasks
 	case "a":
-		if m.ctx.StatusFilter == "attention" {
-			m.ctx.StatusFilter = "all"
-		} else {
-			m.ctx.StatusFilter = "attention"
-		}
+		m.cycleFilter(1)
 		m.taskList.SetLoading(true)
 		return m, m.fetchTasks
 	case "tab":
@@ -339,7 +335,7 @@ func (m Model) handleLogKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 // cycleFilter cycles through status filters by delta (+1 forward, -1 backward)
 func (m *Model) cycleFilter(delta int) {
-	filters := []string{"all", "attention", "active", "completed", "failed"}
+	filters := []string{"attention", "active", "completed", "failed", "all"}
 	for i, f := range filters {
 		if f == m.ctx.StatusFilter {
 			next := (i + delta) % len(filters)

--- a/internal/tui/ui_test.go
+++ b/internal/tui/ui_test.go
@@ -221,16 +221,22 @@ func TestUpdateFooterHints_DetailViewShowsResumeForResumableSession(t *testing.T
 
 func TestCycleFilterForwardAndBackward(t *testing.T) {
 	m := NewModel("", false)
-	m.ctx.StatusFilter = "all"
+	// New order: attention → active → completed → failed → all
+	m.ctx.StatusFilter = "attention"
 
 	m.cycleFilter(1)
+	if m.ctx.StatusFilter != "active" {
+		t.Fatalf("expected active after forward cycle from attention, got %q", m.ctx.StatusFilter)
+	}
+
+	m.cycleFilter(-1)
 	if m.ctx.StatusFilter != "attention" {
-		t.Fatalf("expected attention after forward cycle, got %q", m.ctx.StatusFilter)
+		t.Fatalf("expected attention after backward cycle from active, got %q", m.ctx.StatusFilter)
 	}
 
 	m.cycleFilter(-1)
 	if m.ctx.StatusFilter != "all" {
-		t.Fatalf("expected all after backward cycle, got %q", m.ctx.StatusFilter)
+		t.Fatalf("expected all when cycling backward from attention, got %q", m.ctx.StatusFilter)
 	}
 
 	m.cycleFilter(-1)
@@ -239,17 +245,17 @@ func TestCycleFilterForwardAndBackward(t *testing.T) {
 	}
 }
 
-func TestHandleListKeys_AttentionToggle(t *testing.T) {
+func TestHandleListKeys_ACyclesForward(t *testing.T) {
 	m := NewModel("", false)
-	m.ctx.StatusFilter = "all"
+	m.ctx.StatusFilter = "attention"
 
 	updated, cmd := m.handleListKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
 	if cmd == nil {
-		t.Fatal("expected fetch command when toggling attention mode")
+		t.Fatal("expected fetch command when pressing 'a'")
 	}
 	updatedModel := updated.(Model)
-	if updatedModel.ctx.StatusFilter != "attention" {
-		t.Fatalf("expected attention filter, got %q", updatedModel.ctx.StatusFilter)
+	if updatedModel.ctx.StatusFilter != "active" {
+		t.Fatalf("expected active after 'a' from attention, got %q", updatedModel.ctx.StatusFilter)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #49 and #50.

### Bug: `a` key toggled instead of cycling (#49)
Pressing `a` toggled between "attention" and "all". Now it cycles forward through all filters, same as `Tab`.

### Enhancement: Reorder filter tabs (#50)
**Before:** ALL → ACTION → RUNNING → DONE → FAILED
**After:** ACTION → RUNNING → DONE → FAILED → ALL

ALL is a catch-all view and belongs at the end. ACTION (attention) is the most useful starting point and remains the default.

## Changes
- `ui.go`: `a` key calls `cycleFilter(1)` instead of hardcoded toggle; filter order updated
- `header.go`: Tab bar renders in new order; default fallback changed to "attention"
- `ui_test.go`: Tests updated for new order and `a` key behavior