### PR TITLE
fix: persist dismissed sessions across restarts

### DIFF
--- a/internal/data/dismissed.go
+++ b/internal/data/dismissed.go
@@ -1,0 +1,85 @@
+package data
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+const dismissedFileName = ".gh-agent-viz-dismissed.json"
+
+// DismissedStore manages a persistent set of dismissed session IDs.
+type DismissedStore struct {
+	mu   sync.Mutex
+	ids  map[string]struct{}
+	path string
+}
+
+// NewDismissedStore loads dismissed IDs from the default file.
+// If the file is missing or corrupt, starts with an empty set.
+func NewDismissedStore() *DismissedStore {
+	path := dismissedFilePath()
+	s := &DismissedStore{
+		ids:  map[string]struct{}{},
+		path: path,
+	}
+	s.load()
+	return s
+}
+
+// IDs returns a copy of the dismissed ID set.
+func (s *DismissedStore) IDs() map[string]struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make(map[string]struct{}, len(s.ids))
+	for id := range s.ids {
+		out[id] = struct{}{}
+	}
+	return out
+}
+
+// Add marks a session ID as dismissed and persists to disk.
+func (s *DismissedStore) Add(id string) {
+	if id == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ids[id] = struct{}{}
+	s.save()
+}
+
+func (s *DismissedStore) load() {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		return
+	}
+	var ids []string
+	if err := json.Unmarshal(data, &ids); err != nil {
+		return
+	}
+	for _, id := range ids {
+		s.ids[id] = struct{}{}
+	}
+}
+
+func (s *DismissedStore) save() {
+	ids := make([]string, 0, len(s.ids))
+	for id := range s.ids {
+		ids = append(ids, id)
+	}
+	data, err := json.Marshal(ids)
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(s.path, data, 0600)
+}
+
+func dismissedFilePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return dismissedFileName
+	}
+	return filepath.Join(home, dismissedFileName)
+}

--- a/internal/data/dismissed_test.go
+++ b/internal/data/dismissed_test.go
@@ -1,0 +1,157 @@
+package data
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDismissedStore_AddAndIDs(t *testing.T) {
+	dir := t.TempDir()
+	s := &DismissedStore{
+		ids:  map[string]struct{}{},
+		path: filepath.Join(dir, "dismissed.json"),
+	}
+
+	s.Add("abc")
+	s.Add("def")
+
+	ids := s.IDs()
+	if _, ok := ids["abc"]; !ok {
+		t.Error("expected abc in dismissed IDs")
+	}
+	if _, ok := ids["def"]; !ok {
+		t.Error("expected def in dismissed IDs")
+	}
+	if len(ids) != 2 {
+		t.Errorf("expected 2 IDs, got %d", len(ids))
+	}
+}
+
+func TestDismissedStore_AddEmpty(t *testing.T) {
+	dir := t.TempDir()
+	s := &DismissedStore{
+		ids:  map[string]struct{}{},
+		path: filepath.Join(dir, "dismissed.json"),
+	}
+
+	s.Add("")
+	if len(s.IDs()) != 0 {
+		t.Error("empty ID should not be added")
+	}
+}
+
+func TestDismissedStore_PersistsAcrossReload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dismissed.json")
+
+	s1 := &DismissedStore{
+		ids:  map[string]struct{}{},
+		path: path,
+	}
+	s1.Add("session-1")
+	s1.Add("session-2")
+
+	// Load fresh from same file
+	s2 := &DismissedStore{
+		ids:  map[string]struct{}{},
+		path: path,
+	}
+	s2.load()
+
+	ids := s2.IDs()
+	if len(ids) != 2 {
+		t.Fatalf("expected 2 IDs after reload, got %d", len(ids))
+	}
+	if _, ok := ids["session-1"]; !ok {
+		t.Error("expected session-1 after reload")
+	}
+	if _, ok := ids["session-2"]; !ok {
+		t.Error("expected session-2 after reload")
+	}
+}
+
+func TestDismissedStore_MissingFile(t *testing.T) {
+	s := &DismissedStore{
+		ids:  map[string]struct{}{},
+		path: "/nonexistent/path/dismissed.json",
+	}
+	s.load()
+	if len(s.IDs()) != 0 {
+		t.Error("expected empty set when file is missing")
+	}
+}
+
+func TestDismissedStore_CorruptFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dismissed.json")
+	_ = os.WriteFile(path, []byte("not json!!!"), 0600)
+
+	s := &DismissedStore{
+		ids:  map[string]struct{}{},
+		path: path,
+	}
+	s.load()
+	if len(s.IDs()) != 0 {
+		t.Error("expected empty set when file is corrupt")
+	}
+}
+
+func TestDismissedStore_Deduplication(t *testing.T) {
+	dir := t.TempDir()
+	s := &DismissedStore{
+		ids:  map[string]struct{}{},
+		path: filepath.Join(dir, "dismissed.json"),
+	}
+
+	s.Add("same-id")
+	s.Add("same-id")
+	s.Add("same-id")
+
+	if len(s.IDs()) != 1 {
+		t.Errorf("expected 1 ID after dedup, got %d", len(s.IDs()))
+	}
+}
+
+func TestDismissedStore_FilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dismissed.json")
+
+	s := &DismissedStore{
+		ids:  map[string]struct{}{},
+		path: path,
+	}
+	s.Add("test")
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("expected file to exist: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("expected 0600 permissions, got %o", info.Mode().Perm())
+	}
+}
+
+func TestDismissedStore_FileFormatIsJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dismissed.json")
+
+	s := &DismissedStore{
+		ids:  map[string]struct{}{},
+		path: path,
+	}
+	s.Add("id-1")
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	var ids []string
+	if err := json.Unmarshal(raw, &ids); err != nil {
+		t.Fatalf("file is not valid JSON: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "id-1" {
+		t.Errorf("unexpected file content: %v", ids)
+	}
+}

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -79,13 +79,15 @@ func NewModel(repo string, debug bool) Model {
 		keys.ExitApp,
 	}
 
+	dismissedStore := data.NewDismissedStore()
+
 	return Model{
 		ctx:        ctx,
 		theme:      theme,
 		keys:       keys,
 		header:     header.New(theme.Title, theme.TabActive, theme.TabInactive, theme.TabCount, "⚡ Agent Sessions", &ctx.StatusFilter),
 		footer:     footer.New(theme.Footer, footerKeys),
-		taskList:   tasklist.New(theme.Title, theme.TableHeader, theme.TableRow, theme.TableRowSelected, StatusIcon),
+		taskList:   tasklist.NewWithStore(theme.Title, theme.TableHeader, theme.TableRow, theme.TableRowSelected, StatusIcon, dismissedStore),
 		taskDetail: taskdetail.New(theme.Title, theme.Border, StatusIcon),
 		logView:    logview.New(theme.Title, 80, 20),
 		viewMode:   ViewModeList,


### PR DESCRIPTION
## Summary

Fixes #52 — dismissed sessions reappeared after restarting `gh agent-viz`.

## Root Cause

Dismissed IDs were stored only in an in-memory `map[string]struct{}`, lost on restart.

## Fix

New `DismissedStore` in `internal/data/dismissed.go`:
- Persists dismissed session IDs to `~/.gh-agent-viz-dismissed.json`
- Loaded on startup, saved on each dismissal
- File created lazily (only when first session is dismissed)
- 0600 permissions for security
- Graceful fallback if file is missing or corrupt

The tasklist accepts the store via `NewWithStore()` and persists on dismiss. Existing `New()` constructor unchanged for backward compatibility.

## Tests

8 new tests covering add, dedup, persistence round-trip, missing file, corrupt file, and file permissions.