### PR TITLE
fix: show loading indicator on startup instead of empty state

### DIFF
--- a/internal/tui/components/tasklist/tasklist.go
+++ b/internal/tui/components/tasklist/tasklist.go
@@ -50,7 +50,7 @@ func NewWithStore(titleStyle, headerStyle, rowStyle, rowSelectedStyle lipgloss.S
 		dismissedIDs:     dismissed,
 		dismissedStore:   store,
 		rowCursor:        0,
-		loading:          false,
+		loading:          true,
 		statusIcon:       statusIconFunc,
 		width:            80,
 		height:           24,
@@ -75,7 +75,7 @@ func (m *Model) SetLoading(loading bool) {
 // View renders the sessions as a focused single-column list
 func (m Model) View() string {
 	if m.loading {
-		return m.titleStyle.Render("🔄 Switching gears...\n\nFetching sessions, one moment.")
+		return m.titleStyle.Render("🔄 Loading sessions...\n\nFetching your agent sessions, one moment.")
 	}
 
 	if len(m.sessions) == 0 {
@@ -215,6 +215,7 @@ func (m Model) renderRow(sessionIdx int, session data.Session, selected bool, wi
 
 // SetTasks updates sessions with sorting and de-emphasis
 func (m *Model) SetTasks(sessions []data.Session) {
+	m.loading = false
 	if selected := m.SelectedTask(); selected != nil {
 		m.selectedSessionID = selected.ID
 	}

--- a/internal/tui/components/tasklist/tasklist_test.go
+++ b/internal/tui/components/tasklist/tasklist_test.go
@@ -96,13 +96,15 @@ func TestViewShowsFocusedList(t *testing.T) {
 
 func TestViewEmptyAndLoadingStates(t *testing.T) {
 	model := newModel()
-	if got := model.View(); !strings.Contains(got, "All quiet on the agent front") {
-		t.Fatalf("expected empty state, got: %s", got)
+	// Default state is loading
+	if got := model.View(); !strings.Contains(got, "Loading sessions") {
+		t.Fatalf("expected loading state on init, got: %s", got)
 	}
 
-	model.loading = true
-	if got := model.View(); !strings.Contains(got, "Switching gears") {
-		t.Fatalf("expected loading state, got: %s", got)
+	// After data arrives, loading is false — show empty state
+	model.loading = false
+	if got := model.View(); !strings.Contains(got, "All quiet on the agent front") {
+		t.Fatalf("expected empty state, got: %s", got)
 	}
 }
 
@@ -215,6 +217,7 @@ func TestView_ImprovedEmptyState(t *testing.T) {
 		lipgloss.NewStyle(),
 		func(s string) string { return "" },
 	)
+	model.loading = false
 
 	view := model.View()
 	if !strings.Contains(view, "All quiet on the agent front") {


### PR DESCRIPTION
Fixes #54

On startup the tasklist showed "All quiet on the agent front" briefly before sessions loaded. Now it defaults to `loading: true` and shows "🔄 Loading sessions..." until data arrives.

Also makes `SetTasks()` clear the loading flag automatically, keeping the behavior consistent whether called from tests or the TUI.