### PR TITLE
feat: animated braille spinners for running/queued sessions

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,15 @@ type Config struct {
 	Repos           []string `yaml:"repos"`
 	RefreshInterval int      `yaml:"refreshInterval"`
 	DefaultFilter   string   `yaml:"defaultFilter"`
+	Animations      *bool    `yaml:"animations,omitempty"`
+}
+
+// AnimationsEnabled returns whether animations are enabled (default: true).
+func (c *Config) AnimationsEnabled() bool {
+	if c.Animations == nil {
+		return true
+	}
+	return *c.Animations
 }
 
 // DefaultConfig returns the default configuration

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -164,3 +164,46 @@ func TestSave(t *testing.T) {
 		t.Errorf("expected DefaultFilter of 'completed' after save/load, got '%s'", loadedCfg.DefaultFilter)
 	}
 }
+
+func TestAnimationsEnabled_DefaultTrue(t *testing.T) {
+	cfg := DefaultConfig()
+	if !cfg.AnimationsEnabled() {
+		t.Error("expected animations enabled by default")
+	}
+}
+
+func TestAnimationsEnabled_ExplicitTrue(t *testing.T) {
+	b := true
+	cfg := &Config{Animations: &b}
+	if !cfg.AnimationsEnabled() {
+		t.Error("expected animations enabled when explicitly true")
+	}
+}
+
+func TestAnimationsEnabled_ExplicitFalse(t *testing.T) {
+	b := false
+	cfg := &Config{Animations: &b}
+	if cfg.AnimationsEnabled() {
+		t.Error("expected animations disabled when explicitly false")
+	}
+}
+
+func TestLoad_AnimationsFalse(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "anim-config.yml")
+
+	configContent := "animations: false\n"
+	err := os.WriteFile(configPath, []byte(configContent), 0644)
+	if err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error loading config: %v", err)
+	}
+
+	if cfg.AnimationsEnabled() {
+		t.Error("expected animations disabled from config file")
+	}
+}

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -101,3 +101,23 @@ func StatusIcon(status string) string {
 		return "⚪"
 	}
 }
+
+// Braille spinner frames for running sessions
+var runningFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// Pulsing dot frames for queued sessions
+var queuedFrames = []string{"⠿", "⠷", "⠯", "⠟", "⠻", "⠽"}
+
+// AnimatedStatusIcon returns an animated icon for running/queued statuses,
+// or the static icon for all other statuses. The frame parameter selects
+// which animation frame to display.
+func AnimatedStatusIcon(status string, frame int) string {
+	switch status {
+	case "running":
+		return runningFrames[frame%len(runningFrames)]
+	case "queued":
+		return queuedFrames[frame%len(queuedFrames)]
+	default:
+		return StatusIcon(status)
+	}
+}

--- a/internal/tui/theme_test.go
+++ b/internal/tui/theme_test.go
@@ -78,3 +78,58 @@ func TestNewTheme(t *testing.T) {
 	// lipgloss.Style fields contain functions and cannot be compared directly,
 	// so we just verify the function completed successfully and returned a theme
 }
+
+func TestAnimatedStatusIcon_Running(t *testing.T) {
+	// Frame 0 should return first braille frame
+	icon := AnimatedStatusIcon("running", 0)
+	if icon != "⠋" {
+		t.Errorf("expected ⠋ for running frame 0, got %q", icon)
+	}
+	// Frame 1 should return second braille frame
+	icon = AnimatedStatusIcon("running", 1)
+	if icon != "⠙" {
+		t.Errorf("expected ⠙ for running frame 1, got %q", icon)
+	}
+}
+
+func TestAnimatedStatusIcon_Queued(t *testing.T) {
+	icon := AnimatedStatusIcon("queued", 0)
+	if icon != "⠿" {
+		t.Errorf("expected ⠿ for queued frame 0, got %q", icon)
+	}
+	icon = AnimatedStatusIcon("queued", 1)
+	if icon != "⠷" {
+		t.Errorf("expected ⠷ for queued frame 1, got %q", icon)
+	}
+}
+
+func TestAnimatedStatusIcon_WrapsFrames(t *testing.T) {
+	// Frame 10 should wrap to frame 0 for running (10 frames)
+	icon := AnimatedStatusIcon("running", 10)
+	if icon != "⠋" {
+		t.Errorf("expected ⠋ for running frame 10 (wrap), got %q", icon)
+	}
+	// Frame 6 should wrap to frame 0 for queued (6 frames)
+	icon = AnimatedStatusIcon("queued", 6)
+	if icon != "⠿" {
+		t.Errorf("expected ⠿ for queued frame 6 (wrap), got %q", icon)
+	}
+}
+
+func TestAnimatedStatusIcon_StaticForOtherStatuses(t *testing.T) {
+	tests := []struct {
+		status   string
+		expected string
+	}{
+		{"completed", "✅"},
+		{"failed", "❌"},
+		{"needs-input", "🧑"},
+		{"unknown", "⚪"},
+	}
+	for _, tt := range tests {
+		icon := AnimatedStatusIcon(tt.status, 5)
+		if icon != tt.expected {
+			t.Errorf("expected %q for %s, got %q", tt.expected, tt.status, icon)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Replaces static emoji status indicators (🟢🟡) with animated braille spinners for running sessions and pulsing dots for queued sessions, making the UI feel alive.

## Changes
- **Config**: Added `animations` toggle (default: `true`), `AnimationsEnabled()` method
- **Theme**: Added `AnimatedStatusIcon(status, frame)` with braille spinner frames (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) and queued pulsing frames
- **UI**: Added 100ms `animationTickMsg` (separate from 30s refresh), `animFrame` counter
- **Tasklist**: Accepts animated icon func, `SetAnimFrame()` updates current frame, falls back to static when animations disabled
- **Tests**: Coverage for animation frame cycling, wrapping, config parsing

## Demo
Running sessions cycle through: `⠋ → ⠙ → ⠹ → ⠸ → ⠼ → ⠴ → ⠦ → ⠧ → ⠇ → ⠏`
Queued sessions pulse: `⠿ → ⠷ → ⠯ → ⠟ → ⠻ → ⠽`

Disable with `animations: false` in config.

Closes #58