### PR TITLE
fix: default preview pane to closed on startup and tab switch

### DIFF
--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -99,7 +99,7 @@ func NewModel(repo string, debug bool) Model {
 		taskDetail:  taskdetail.New(theme.Title, theme.Border, StatusIcon),
 		logView:     logview.New(theme.Title, 80, 20),
 		viewMode:    ViewModeList,
-		showPreview: true,
+		showPreview: false,
 		ready:       false,
 		repo:        repo,
 		refreshInt:  time.Duration(refreshSeconds) * time.Second,
@@ -377,6 +377,7 @@ func (m *Model) cycleFilter(delta int) {
 				next += len(filters)
 			}
 			m.ctx.StatusFilter = filters[next]
+			m.showPreview = false
 			break
 		}
 	}


### PR DESCRIPTION
Preview pane now starts closed and closes when switching filter tabs. Users open it explicitly with `p` when they want to inspect a session.

Two-line change in `ui.go`:
1. `showPreview: false` (was `true`) in constructor
2. `m.showPreview = false` added to `cycleFilter()`

Closes #69