### PR TITLE
feat: sparkline activity indicators in session list (#59)

### DIFF
--- a/internal/tui/components/sparkline/sparkline.go
+++ b/internal/tui/components/sparkline/sparkline.go
@@ -1,0 +1,133 @@
+package sparkline
+
+import (
+	"math"
+	"strings"
+	"time"
+)
+
+// blocks maps normalized values (0.0–1.0) to Unicode block characters.
+var blocks = []rune{'▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'}
+
+// Generate returns a sparkline string of the given width visualizing activity
+// recency. Running sessions ramp up toward the right, completed sessions peak
+// early then decay, and queued sessions stay mostly flat.
+func Generate(status string, createdAt, updatedAt time.Time, width int) string {
+	if width <= 0 {
+		width = 8
+	}
+
+	status = normalizeStatus(status)
+
+	// Fallback when timestamps are missing.
+	if createdAt.IsZero() && updatedAt.IsZero() {
+		return fallback(status, width)
+	}
+
+	now := time.Now()
+
+	switch status {
+	case "queued":
+		return queued(width)
+	case "running", "active", "in progress", "open":
+		return running(createdAt, updatedAt, now, width)
+	default:
+		return completed(createdAt, updatedAt, now, width)
+	}
+}
+
+// running produces a ramp-up sparkline: activity increases toward the right.
+func running(createdAt, updatedAt, now time.Time, width int) string {
+	var buf strings.Builder
+	buf.Grow(width * 4) // up to 4 bytes per rune
+	for i := range width {
+		t := float64(i) / float64(width-1)
+		// Quadratic ease-in gives a pleasing ramp.
+		v := t * t
+		buf.WriteRune(blockChar(v))
+	}
+	return buf.String()
+}
+
+// completed produces a decay sparkline: peaks early then fades.
+// The faster it faded (longer since updatedAt), the steeper the decay.
+func completed(createdAt, updatedAt, now time.Time, width int) string {
+	// recencyRatio: 0 = just finished, 1 = finished long ago.
+	age := now.Sub(createdAt).Seconds()
+	if age <= 0 {
+		age = 1
+	}
+	recency := now.Sub(updatedAt).Seconds()
+	if recency < 0 {
+		recency = 0
+	}
+	recencyRatio := recency / age
+	if recencyRatio > 1 {
+		recencyRatio = 1
+	}
+
+	// peakPos: where in [0,1) the sparkline peaks.
+	// Recent completions peak near the middle; old ones peak near the left.
+	peakPos := 0.5 * (1 - recencyRatio)
+	if peakPos < 0.05 {
+		peakPos = 0.05
+	}
+
+	var buf strings.Builder
+	buf.Grow(width * 4)
+	for i := range width {
+		t := float64(i) / float64(width-1)
+		dist := math.Abs(t - peakPos)
+		v := math.Exp(-3 * dist / (1 - recencyRatio + 0.15))
+		if v > 1 {
+			v = 1
+		}
+		buf.WriteRune(blockChar(v))
+	}
+	return buf.String()
+}
+
+// queued produces a mostly-flat sparkline with a slight uptick at the end.
+func queued(width int) string {
+	var buf strings.Builder
+	buf.Grow(width * 4)
+	for i := range width {
+		if i == width-1 {
+			buf.WriteRune(blocks[1]) // ▂
+		} else {
+			buf.WriteRune(blocks[0]) // ▁
+		}
+	}
+	return buf.String()
+}
+
+// fallback returns a uniform sparkline based on status when timestamps are
+// missing.
+func fallback(status string, width int) string {
+	var ch rune
+	switch status {
+	case "running", "active", "in progress", "open":
+		ch = blocks[7] // █
+	case "completed", "stopped", "done":
+		ch = blocks[3] // ▄
+	default:
+		ch = blocks[0] // ▁
+	}
+	return strings.Repeat(string(ch), width)
+}
+
+// blockChar maps a value in [0,1] to a block character.
+func blockChar(v float64) rune {
+	idx := int(v * float64(len(blocks)-1))
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(blocks) {
+		idx = len(blocks) - 1
+	}
+	return blocks[idx]
+}
+
+func normalizeStatus(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}

--- a/internal/tui/components/sparkline/sparkline_test.go
+++ b/internal/tui/components/sparkline/sparkline_test.go
@@ -1,0 +1,146 @@
+package sparkline
+
+import (
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+var validBlocks = map[rune]bool{
+	'▁': true, '▂': true, '▃': true, '▄': true,
+	'▅': true, '▆': true, '▇': true, '█': true,
+}
+
+func TestGenerateRunningSession(t *testing.T) {
+	now := time.Now()
+	created := now.Add(-30 * time.Minute)
+	updated := now.Add(-1 * time.Minute) // recently active
+
+	result := Generate("running", created, updated, 8)
+
+	if utf8.RuneCountInString(result) != 8 {
+		t.Errorf("expected 8 runes, got %d: %q", utf8.RuneCountInString(result), result)
+	}
+
+	runes := []rune(result)
+	// Running should ramp up: first char <= last char
+	if runes[0] > runes[len(runes)-1] {
+		t.Errorf("running sparkline should ramp up, got %q", result)
+	}
+}
+
+func TestGenerateCompletedSession(t *testing.T) {
+	now := time.Now()
+	created := now.Add(-24 * time.Hour)
+	updated := now.Add(-23 * time.Hour) // finished long ago
+
+	result := Generate("completed", created, updated, 8)
+
+	if utf8.RuneCountInString(result) != 8 {
+		t.Errorf("expected 8 runes, got %d: %q", utf8.RuneCountInString(result), result)
+	}
+
+	runes := []rune(result)
+	// Completed old session: first chars should be >= last chars
+	if runes[0] < runes[len(runes)-1] {
+		t.Errorf("old completed sparkline should peak early, got %q", result)
+	}
+}
+
+func TestGenerateQueuedSession(t *testing.T) {
+	now := time.Now()
+	created := now.Add(-1 * time.Minute)
+	updated := created
+
+	result := Generate("queued", created, updated, 8)
+
+	runes := []rune(result)
+	if utf8.RuneCountInString(result) != 8 {
+		t.Errorf("expected 8 runes, got %d: %q", utf8.RuneCountInString(result), result)
+	}
+
+	// All but last should be ▁, last should be ▂
+	for i, r := range runes {
+		if i < len(runes)-1 {
+			if r != '▁' {
+				t.Errorf("queued sparkline position %d should be ▁, got %c", i, r)
+			}
+		} else {
+			if r != '▂' {
+				t.Errorf("queued sparkline last position should be ▂, got %c", r)
+			}
+		}
+	}
+}
+
+func TestGenerateZeroTimestamps(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   string
+		expected rune
+	}{
+		{"running fallback", "running", '█'},
+		{"completed fallback", "completed", '▄'},
+		{"unknown fallback", "unknown-status", '▁'},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Generate(tt.status, time.Time{}, time.Time{}, 8)
+			if utf8.RuneCountInString(result) != 8 {
+				t.Errorf("expected 8 runes, got %d", utf8.RuneCountInString(result))
+			}
+			expected := strings.Repeat(string(tt.expected), 8)
+			if result != expected {
+				t.Errorf("expected %q, got %q", expected, result)
+			}
+		})
+	}
+}
+
+func TestGenerateCorrectWidth(t *testing.T) {
+	now := time.Now()
+	created := now.Add(-1 * time.Hour)
+	updated := now.Add(-5 * time.Minute)
+
+	for _, w := range []int{1, 4, 8, 12, 20} {
+		result := Generate("running", created, updated, w)
+		got := utf8.RuneCountInString(result)
+		if got != w {
+			t.Errorf("width %d: expected %d runes, got %d", w, w, got)
+		}
+	}
+}
+
+func TestGenerateDefaultWidth(t *testing.T) {
+	result := Generate("running", time.Time{}, time.Time{}, 0)
+	if utf8.RuneCountInString(result) != 8 {
+		t.Errorf("default width should be 8, got %d", utf8.RuneCountInString(result))
+	}
+}
+
+func TestGenerateOnlyValidBlocks(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		status  string
+		created time.Time
+		updated time.Time
+	}{
+		{"running", now.Add(-1 * time.Hour), now.Add(-1 * time.Minute)},
+		{"completed", now.Add(-24 * time.Hour), now.Add(-12 * time.Hour)},
+		{"queued", now.Add(-1 * time.Minute), now.Add(-1 * time.Minute)},
+		{"running", time.Time{}, time.Time{}},
+		{"unknown", time.Time{}, time.Time{}},
+	}
+
+	for _, tc := range cases {
+		result := Generate(tc.status, tc.created, tc.updated, 8)
+		for _, r := range result {
+			if !validBlocks[r] {
+				t.Errorf("invalid block char %c (U+%04X) in %q for status=%q",
+					r, r, result, tc.status)
+			}
+		}
+	}
+}

--- a/internal/tui/components/tasklist/tasklist.go
+++ b/internal/tui/components/tasklist/tasklist.go
@@ -9,6 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/maxbeizer/gh-agent-viz/internal/data"
+	"github.com/maxbeizer/gh-agent-viz/internal/tui/components/sparkline"
 )
 
 // Model represents the task list component state
@@ -142,7 +143,16 @@ func (m Model) renderRow(sessionIdx int, session data.Session, selected bool, wi
 	}
 
 	icon := m.currentStatusIcon(session.Status)
-	titleMax := width - 8
+
+	const sparkWidth = 8
+	showSparkline := width >= 60
+
+	// Account for gutter(2) + icon(~2) + spaces; sparkline adds sparkWidth+1
+	overhead := 8
+	if showSparkline {
+		overhead += sparkWidth + 1
+	}
+	titleMax := width - overhead
 	if titleMax < 3 {
 		titleMax = 3
 	}
@@ -155,7 +165,13 @@ func (m Model) renderRow(sessionIdx int, session data.Session, selected bool, wi
 		gutter = "▎ "
 	}
 
-	titleLine := fmt.Sprintf("%s%s %s", gutter, icon, title)
+	var titleLine string
+	if showSparkline {
+		spark := sparkline.Generate(session.Status, session.CreatedAt, session.UpdatedAt, sparkWidth)
+		titleLine = fmt.Sprintf("%s%s %s %s", gutter, icon, spark, title)
+	} else {
+		titleLine = fmt.Sprintf("%s%s %s", gutter, icon, title)
+	}
 	if badge != "" {
 		titleLine += " " + badge
 	}


### PR DESCRIPTION
## Summary

Add inline sparkline mini-charts next to each session in the list view, visualizing activity recency using Unicode block characters (`▁▂▃▄▅▆▇█`).

### What this does

- **New `sparkline` package** at `internal/tui/components/sparkline/` — a pure function that takes status, timestamps, and width, returning a Unicode sparkline string
- **Integrated into session list** — sparklines appear between the status icon and session title when terminal width ≥ 60
- **Visual patterns by status**:
  - Running sessions: ramp up (`▁▂▃▅▆▇█▇`) — activity increasing toward now
  - Completed sessions: peak then decay (`█▇▅▃▂▁▁▁`) — activity was in the past
  - Queued sessions: mostly flat (`▁▁▁▁▁▁▁▂`) — barely started
  - Missing timestamps: uniform block based on status
- **Responsive** — sparklines hidden on narrow terminals (< 60 cols)
- **Comprehensive tests** covering all status types, width correctness, fallback behavior, and character validation

### No new dependencies
Pure Unicode string generation — no external packages needed.

Closes #59