### PR TITLE
feat: ASCII art header branding banner (#67)

### DIFF
--- a/.gh-agent-viz.yml.example
+++ b/.gh-agent-viz.yml.example
@@ -11,3 +11,6 @@ refreshInterval: 30
 
 # Default status filter: all, active, completed, failed (default: all)
 defaultFilter: all
+
+# Show ASCII art banner in header (default: true)
+asciiHeader: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	RefreshInterval int      `yaml:"refreshInterval"`
 	DefaultFilter   string   `yaml:"defaultFilter"`
 	Animations      *bool    `yaml:"animations,omitempty"`
+	AsciiHeader     *bool    `yaml:"asciiHeader,omitempty"`
 }
 
 // AnimationsEnabled returns whether animations are enabled (default: true).
@@ -21,6 +22,14 @@ func (c *Config) AnimationsEnabled() bool {
 		return true
 	}
 	return *c.Animations
+}
+
+// AsciiHeaderEnabled returns whether the ASCII art header is enabled (default: true).
+func (c *Config) AsciiHeaderEnabled() bool {
+	if c.AsciiHeader == nil {
+		return true
+	}
+	return *c.AsciiHeader
 }
 
 // DefaultConfig returns the default configuration

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -93,7 +93,7 @@ func NewModel(repo string, debug bool) Model {
 		ctx:         ctx,
 		theme:       theme,
 		keys:        keys,
-		header:      header.New(theme.Title, theme.TabActive, theme.TabInactive, theme.TabCount, "⚡ Agent Sessions", &ctx.StatusFilter),
+		header:      header.New(theme.Title, theme.TabActive, theme.TabInactive, theme.TabCount, "⚡ Agent Sessions", &ctx.StatusFilter, ctx.Config.AsciiHeaderEnabled()),
 		footer:      footer.New(theme.Footer, footerKeys),
 		taskList:    tasklist.NewWithStore(theme.Title, theme.TableHeader, theme.TableRow, theme.TableRowSelected, StatusIcon, animIconFunc, dismissedStore),
 		taskDetail:  taskdetail.New(theme.Title, theme.Border, StatusIcon),
@@ -125,6 +125,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.ctx.Width = msg.Width
 		m.ctx.Height = msg.Height
+		m.header.SetSize(msg.Width, msg.Height)
 		m.logView.SetSize(msg.Width-4, msg.Height-8)
 		m.updateSplitLayout()
 		m.ready = true


### PR DESCRIPTION
## Summary

Replace the plain "⚡ Agent Sessions" header text with a compact ASCII art banner for a polished, branded look.

```
┌─────────────────────────┐
│  A G E N T   V I Z  ⚡  │
└─────────────────────────┘
```

## Changes

- **Config**: Added `asciiHeader` key (`*bool`, default: `true`) with `AsciiHeaderEnabled()` method
- **Header component**: Added `useAsciiHeader` field, `SetSize(width, height)` method, and banner rendering logic
- **Responsive layout**: Banner is hidden when terminal height < 15 rows or width < 27 columns
- **UI wiring**: Pass config setting to header, forward `WindowSizeMsg` dimensions
- **Tests**: 6 new tests covering enabled/disabled banner, short terminal, narrow terminal, and boundary cases
- **Example config**: Added `asciiHeader: true` entry

## Validation

- `go build ./...` ✅
- `go test ./...` ✅ (all existing + new tests pass)

Closes #67