### PR TITLE
fix: enable log viewing for local Copilot CLI sessions

### DIFF
--- a/internal/data/session.go
+++ b/internal/data/session.go
@@ -37,6 +37,7 @@ type Session struct {
 	UpdatedAt  time.Time     `json:"updatedAt"`
 	Source     SessionSource `json:"source"`
 	Telemetry  *SessionTelemetry `json:"telemetry,omitempty"`
+	HasLog     bool              `json:"-"` // true when a viewable log exists (e.g. events.jsonl)
 }
 
 // FromAgentTask converts an AgentTask to a Session

--- a/internal/tui/ui_test.go
+++ b/internal/tui/ui_test.go
@@ -259,7 +259,7 @@ func TestHandleListKeys_ACyclesForward(t *testing.T) {
 	}
 }
 
-func TestHandleListKeys_LocalSessionLogShowsHelpfulError(t *testing.T) {
+func TestHandleListKeys_LocalSessionLogSwitchesToLogView(t *testing.T) {
 	m := NewModel("", false)
 	m.taskList.SetTasks([]data.Session{
 		{
@@ -272,16 +272,13 @@ func TestHandleListKeys_LocalSessionLogShowsHelpfulError(t *testing.T) {
 	})
 
 	updated, cmd := m.handleListKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
-	if cmd != nil {
-		t.Fatal("expected no log fetch command for local session")
+	if cmd == nil {
+		t.Fatal("expected log fetch command for local session")
 	}
 
 	updatedModel := updated.(Model)
-	if updatedModel.viewMode != ViewModeList {
-		t.Fatalf("expected list view to remain active, got %v", updatedModel.viewMode)
-	}
-	if updatedModel.ctx.Error == nil {
-		t.Fatal("expected helpful error for local session logs")
+	if updatedModel.viewMode != ViewModeLog {
+		t.Fatalf("expected log view, got %v", updatedModel.viewMode)
 	}
 }
 


### PR DESCRIPTION
## Problem

Pressing `l` on a local Copilot CLI session showed a jarring error: *"logs are only available for remote agent-task sessions"*. This felt broken — the user reasonably expects to see logs for any session.

## Solution

Local sessions store conversation events in `~/.copilot/session-state/<id>/events.jsonl`. This PR:

1. **Reads `events.jsonl`** and renders it as a human-readable conversation log with:
   - 👤 User messages
   - 🤖 Assistant responses
   - 🔧 Tool calls (with tool name)
   - 🚀 Session start / ⛔ Abort markers
   - Timestamps formatted as `HH:MM:SS`

2. **Adds `HasLog` field to Session** — set during local session parsing when `events.jsonl` exists and is non-empty

3. **Updates `canShowLogs()`** — the `l` keyhint now appears for local sessions that have logs

4. **Markdown rendering** — the log output is formatted as markdown, so it benefits from the glamour rendering added in #75

## Testing

- 10 new tests for event formatting, truncation, edge cases
- Updated existing test to reflect new behavior
- All tests pass

## Before / After

**Before:** Error message, stuck in list view
**After:** Rich conversation log with user/assistant/tool events, rendered with glamour markdown