### PR TITLE
fix: "a" key jumps to ACTION tab, sparklines moved to meta line

### DIFF
--- a/internal/tui/components/tasklist/tasklist.go
+++ b/internal/tui/components/tasklist/tasklist.go
@@ -144,15 +144,7 @@ func (m Model) renderRow(sessionIdx int, session data.Session, selected bool, wi
 
 	icon := m.currentStatusIcon(session.Status)
 
-	const sparkWidth = 8
-	showSparkline := width >= 60
-
-	// Account for gutter(2) + icon(~2) + spaces; sparkline adds sparkWidth+1
-	overhead := 8
-	if showSparkline {
-		overhead += sparkWidth + 1
-	}
-	titleMax := width - overhead
+	titleMax := width - 8
 	if titleMax < 3 {
 		titleMax = 3
 	}
@@ -165,13 +157,7 @@ func (m Model) renderRow(sessionIdx int, session data.Session, selected bool, wi
 		gutter = "▎ "
 	}
 
-	var titleLine string
-	if showSparkline {
-		spark := sparkline.Generate(session.Status, session.CreatedAt, session.UpdatedAt, sparkWidth)
-		titleLine = fmt.Sprintf("%s%s %s %s", gutter, icon, spark, title)
-	} else {
-		titleLine = fmt.Sprintf("%s%s %s", gutter, icon, title)
-	}
+	titleLine := fmt.Sprintf("%s%s %s", gutter, icon, title)
 	if badge != "" {
 		titleLine += " " + badge
 	}
@@ -187,7 +173,11 @@ func (m Model) renderRow(sessionIdx int, session data.Session, selected bool, wi
 
 	repo := truncate(rowRepository(session), metaMax)
 	attention := attentionReason(session)
-	meta := fmt.Sprintf("    %s • %s • %s", repo, attention, formatTime(session.UpdatedAt))
+	spark := ""
+	if width >= 60 {
+		spark = " " + sparkline.Generate(session.Status, session.CreatedAt, session.UpdatedAt, 8)
+	}
+	meta := fmt.Sprintf("    %s • %s • %s%s", repo, attention, formatTime(session.UpdatedAt), spark)
 
 	return style.Render(titleLine + "\n" + meta)
 }

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -294,7 +294,8 @@ func (m Model) handleListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.updateSplitLayout()
 		return m, nil
 	case "a":
-		m.cycleFilter(1)
+		m.ctx.StatusFilter = "attention"
+		m.showPreview = false
 		m.taskList.SetLoading(true)
 		return m, m.fetchTasks
 	case "tab":

--- a/internal/tui/ui_test.go
+++ b/internal/tui/ui_test.go
@@ -245,7 +245,21 @@ func TestCycleFilterForwardAndBackward(t *testing.T) {
 	}
 }
 
-func TestHandleListKeys_ACyclesForward(t *testing.T) {
+func TestHandleListKeys_AJumpsToAttention(t *testing.T) {
+	m := NewModel("", false)
+	m.ctx.StatusFilter = "active" // start on a different tab
+
+	updated, cmd := m.handleListKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if cmd == nil {
+		t.Fatal("expected fetch command when pressing 'a'")
+	}
+	updatedModel := updated.(Model)
+	if updatedModel.ctx.StatusFilter != "attention" {
+		t.Fatalf("expected attention after 'a', got %q", updatedModel.ctx.StatusFilter)
+	}
+}
+
+func TestHandleListKeys_AJumpsToAttentionFromAttention(t *testing.T) {
 	m := NewModel("", false)
 	m.ctx.StatusFilter = "attention"
 
@@ -254,8 +268,8 @@ func TestHandleListKeys_ACyclesForward(t *testing.T) {
 		t.Fatal("expected fetch command when pressing 'a'")
 	}
 	updatedModel := updated.(Model)
-	if updatedModel.ctx.StatusFilter != "active" {
-		t.Fatalf("expected active after 'a' from attention, got %q", updatedModel.ctx.StatusFilter)
+	if updatedModel.ctx.StatusFilter != "attention" {
+		t.Fatalf("expected attention after 'a' from attention, got %q", updatedModel.ctx.StatusFilter)
 	}
 }
 


### PR DESCRIPTION
## Changes

**1. Fix "a" key behavior (#78)**
The `a` key was calling `cycleFilter(1)` — same as `tab`. Now it sets the filter directly to `"attention"`, always jumping to the ACTION tab regardless of which tab is active.

**2. Move sparklines to metadata line**
Sparklines were on the title line, cluttering the most important info. Moved them to the end of the metadata line where they provide context without stealing focus.

**Before:** `▎ ⠋ ▁▂▃▅▇█ Fix auth bug  ⚠ check progress`
**After:**
```
▎ ⠋ Fix auth bug  ⚠ check progress
    owner/repo • running but quiet • 12m ago ▁▂▃▅▇█
```

Closes #78