### PR TITLE
fix: replace vague "⚠ check progress" badge with contextual idle duration

### DIFF
--- a/internal/tui/components/tasklist/tasklist.go
+++ b/internal/tui/components/tasklist/tasklist.go
@@ -368,12 +368,24 @@ func sessionBadge(session data.Session, deEmphasized bool) string {
 		return "↺ quiet duplicate"
 	}
 	if data.SessionNeedsAttention(session) {
-		return "⚠ check progress"
+		return fmt.Sprintf("⏸ idle %s", formatIdleDuration(time.Since(session.UpdatedAt)))
 	}
 	if !isActiveStatus(session.Status) || session.UpdatedAt.IsZero() {
 		return ""
 	}
 	return "• in progress"
+}
+
+func formatIdleDuration(d time.Duration) string {
+	if d < time.Hour {
+		return fmt.Sprintf("~%dm", int(d.Minutes()))
+	}
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	if m == 0 {
+		return fmt.Sprintf("~%dh", h)
+	}
+	return fmt.Sprintf("~%dh%dm", h, m)
 }
 
 func (m Model) isDeEmphasized(sessionIdx int) bool {


### PR DESCRIPTION
## Summary

Replaces the generic `⚠ check progress` badge with a contextual `⏸ idle ~Xm` badge that shows how long a session has been quiet. This makes the indicator actionable — users can see at a glance whether a session has been idle for 25 minutes vs 2 hours.

## Changes

- **`sessionBadge()`** — now renders `⏸ idle ~25m` / `⏸ idle ~1h30m` instead of `⚠ check progress`
- **`formatIdleDuration()`** — new helper that formats durations as `~Xm`, `~Xh`, or `~XhYm`
- **Tests** — added `TestFormatIdleDuration` (7 cases) and `TestSessionBadge_IdleShowsDuration`

## Before / After

| Before | After |
|--------|-------|
| `⚠ check progress` | `⏸ idle ~25m` |
| `⚠ check progress` | `⏸ idle ~1h30m` |

Closes #82