### PR TITLE
fix: make relink-local rebuild binary before reinstalling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,11 @@ run: build
 install-local:
 	gh extension install .
 
-relink-local:
+relink-local: build
 	@if gh extension list | grep -qE '^gh agent-viz[[:space:]]'; then \
 		gh extension remove agent-viz; \
 	fi
+	$(GO) build -o gh-agent-viz ./gh-agent-viz.go
 	gh extension install .
 
 test: check-go-version


### PR DESCRIPTION
The `relink-local` target re-symlinked the extension but did not rebuild the binary at the repo root. Since `gh` runs that binary directly, users would get a stale build after relinking.

Now depends on `build` and also runs `go build -o gh-agent-viz` to ensure the root binary is fresh.