### PR TITLE
feat: tasklist UX overhaul — compact cards, dedup info, auto-grouping

### DIFF
--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -18,6 +18,7 @@ type Keybindings struct {
 	NavigateBack   key.Binding
 	TogglePreview  key.Binding
 	GroupBy        key.Binding
+	ExpandGroup    key.Binding
 }
 
 // NewKeybindings creates the default key bindings for the TUI
@@ -78,6 +79,10 @@ func NewKeybindings() Keybindings {
 		GroupBy: key.NewBinding(
 			key.WithKeys("g"),
 			key.WithHelp("g", "group"),
+		),
+		ExpandGroup: key.NewBinding(
+			key.WithKeys(" "),
+			key.WithHelp("space", "expand/collapse"),
 		),
 	}
 }

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -309,6 +309,11 @@ func (m Model) handleListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "g":
 		m.taskList.CycleGroupBy()
 		return m, nil
+	case " ":
+		if m.taskList.IsGrouped() {
+			m.taskList.ToggleGroupExpand()
+			return m, nil
+		}
 	}
 	return m, nil
 }
@@ -615,6 +620,9 @@ func (m *Model) updateFooterHints() {
 			hints = append(hints, key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "group: "+label)))
 		} else {
 			hints = append(hints, m.keys.GroupBy)
+		}
+		if m.taskList.IsGrouped() {
+			hints = append(hints, m.keys.ExpandGroup)
 		}
 		hints = append(hints, m.keys.ExitApp)
 		m.footer.SetHints(hints)


### PR DESCRIPTION
## Problem

The tasklist is hard to parse with many sessions — every row looks identical, info is repeated 3 times (badge + attentionReason + time), UUID session titles are noise, and no visual grouping.

## Before
```
▎ ⠦ Switch To Main And Pull ⏸ idle ~21m
    copilot-steward @ main • running but quiet • 21m ago • ⏱ < 1m
  ⠦ Session 7967abbc-163d-4975-9803-8d340b6eb590 ⏸ idle ~26m
    1-1-Repo @ main • running but quiet • 26m ago • ⏱ < 1m
```

## After
```
── copilot-steward (3) ──
▎ ⠦ Switch To Main And Pull                       💤 ~21m
    copilot-steward @ main  21m ago                ⏱ < 1m
  ⠦ Untitled session                               💤 ~26m
    1-1-Repo @ main  26m ago                       ⏱ < 1m
```

## Changes

| Change | What |
|--------|------|
| **A. Dedup info** | Badge says `💤 30m`, meta drops redundant `attentionReason` |
| **B. Compact layout** | Right-aligned badge + telemetry columns, no `•` separators |
| **C. UUID titles** | `Session <UUID>` → `Untitled session` |
| **D. Auto-group** | 8+ sessions → auto repo grouping (manual `g` overrides) |
| **Headers** | Cleaner: `── repo-name (3) ──` without dimension prefix |

## Tests
- Updated badge assertions for `💤` emoji
- 3 new UUID title tests
- 2 new auto-group tests (threshold + manual override)

Closes #89