### PR TITLE
feat: age out stale sessions from ACTION tab after 4 hours

### DIFF
--- a/internal/data/session.go
+++ b/internal/data/session.go
@@ -16,6 +16,10 @@ const (
 // AttentionStaleThreshold is the quiet-window threshold for active sessions.
 const AttentionStaleThreshold = 20 * time.Minute
 
+// AttentionStaleMax is the upper bound — sessions idle longer than this
+// are considered abandoned and no longer need attention.
+const AttentionStaleMax = 4 * time.Hour
+
 // SessionTelemetry holds derived usage metrics for a session
 type SessionTelemetry struct {
 	Duration          time.Duration // elapsed time from created to last activity
@@ -82,7 +86,8 @@ func SessionNeedsAttention(session Session) bool {
 		return false
 	}
 
-	return time.Since(session.UpdatedAt) >= AttentionStaleThreshold
+	idle := time.Since(session.UpdatedAt)
+	return idle >= AttentionStaleThreshold && idle < AttentionStaleMax
 }
 
 // StatusIsActive determines if a status string represents an active session.

--- a/internal/data/session_test.go
+++ b/internal/data/session_test.go
@@ -32,6 +32,26 @@ func TestSessionNeedsAttention(t *testing.T) {
 			want:    false,
 		},
 		{
+			name:    "active session idle 2h needs attention",
+			session: Session{Status: "running", UpdatedAt: time.Now().Add(-2 * time.Hour)},
+			want:    true,
+		},
+		{
+			name:    "active session idle 5h past max",
+			session: Session{Status: "running", UpdatedAt: time.Now().Add(-5 * time.Hour)},
+			want:    false,
+		},
+		{
+			name:    "needs-input idle 5h always needs attention",
+			session: Session{Status: "needs-input", UpdatedAt: time.Now().Add(-5 * time.Hour)},
+			want:    true,
+		},
+		{
+			name:    "failed idle 5h always needs attention",
+			session: Session{Status: "failed", UpdatedAt: time.Now().Add(-5 * time.Hour)},
+			want:    true,
+		},
+		{
 			name:    "completed session",
 			session: Session{Status: "completed", UpdatedAt: time.Now().Add(-2 * time.Hour)},
 			want:    false,

--- a/internal/tui/components/tasklist/tasklist.go
+++ b/internal/tui/components/tasklist/tasklist.go
@@ -475,6 +475,9 @@ func sessionBadge(session data.Session, deEmphasized bool, duplicateCount int) s
 		}
 		return badge
 	}
+	if isActiveStatus(session.Status) && !session.UpdatedAt.IsZero() && time.Since(session.UpdatedAt) >= data.AttentionStaleMax {
+		return "😴 stale"
+	}
 	if !isActiveStatus(session.Status) || session.UpdatedAt.IsZero() {
 		return ""
 	}

--- a/internal/tui/components/tasklist/tasklist_test.go
+++ b/internal/tui/components/tasklist/tasklist_test.go
@@ -452,6 +452,17 @@ func TestSessionBadge_IdleShowsDuration(t *testing.T) {
 	}
 }
 
+func TestSessionBadge_StaleShowsEmoji(t *testing.T) {
+	session := data.Session{
+		Status:    "running",
+		UpdatedAt: time.Now().Add(-5 * time.Hour),
+	}
+	badge := sessionBadge(session, false, 0)
+	if badge != "😴 stale" {
+		t.Fatalf("expected stale badge for session idle >4h, got %q", badge)
+	}
+}
+
 func TestCompactDuration(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Closes #92

## Problem

`SessionNeedsAttention()` fired on any running session idle >20 minutes with no upper bound. With many old sessions, the ACTION tab showed ~41 items when only a few genuinely needed attention.

## Changes

### Before
- Any active session idle ≥20 minutes was flagged as needing attention
- No distinction between "idle for 30 minutes" and "abandoned for 8 hours"

### After
- Active sessions idle between 20 minutes and 4 hours show `💤` (needs attention)
- Active sessions idle >4 hours show `😴 stale` (considered abandoned)
- Sessions with `needs-input` or `failed` status **always** need attention regardless of age

### Details
1. Added `AttentionStaleMax = 4h` constant in `internal/data/session.go`
2. Updated `SessionNeedsAttention()` to return true only when idle is in `[20m, 4h)` range
3. Added `😴 stale` badge in `sessionBadge()` for sessions past the max threshold
4. Added tests for the new aging behavior in both data and tasklist packages