### PR TITLE
fix: hide quiet duplicate sessions from list view

### DIFF
--- a/internal/tui/components/tasklist/tasklist.go
+++ b/internal/tui/components/tasklist/tasklist.go
@@ -275,16 +275,17 @@ func (m *Model) SetTasks(sessions []data.Session) {
 		return false
 	})
 
-	m.sessions = make([]data.Session, len(ranked))
+	m.sessions = make([]data.Session, 0, len(ranked))
 	m.deEmphasizedIdx = map[int]struct{}{}
 	m.duplicateCounts = map[int]int{}
-	for i, candidate := range ranked {
-		m.sessions[i] = candidate.session
+	for _, candidate := range ranked {
 		if candidate.deEmphasized {
-			m.deEmphasizedIdx[i] = struct{}{}
+			continue // Hide quiet duplicates entirely
 		}
+		idx := len(m.sessions)
+		m.sessions = append(m.sessions, candidate.session)
 		if count, ok := inputDupCounts[candidate.origIdx]; ok {
-			m.duplicateCounts[i] = count
+			m.duplicateCounts[idx] = count
 		}
 	}
 


### PR DESCRIPTION
Closes #96

## Summary

Hide quiet duplicate sessions entirely from the list view instead of rendering them with faint text and a "↺ quiet duplicate" badge.

## Before

Older duplicate sessions (same title/repo/branch/source, idle >20min) were shown with faint text and a "↺ quiet duplicate" badge, adding visual clutter without much value.

## After

Older duplicates are **removed from the session list entirely**. The newest session in each duplicate group still shows the `(+N older)` count badge so users know duplicates exist. This reduces noise while preserving discoverability.

## Changes

- **`internal/tui/components/tasklist/tasklist.go`**: In `SetTasks()`, skip de-emphasized (quiet duplicate) sessions instead of adding them to `m.sessions`. The `duplicateCounts` map is preserved so the newest duplicate still shows its count badge.
- **`internal/tui/components/tasklist/tasklist_test.go`**: Updated tests to verify older duplicates are absent from `model.sessions` and the "↺ quiet duplicate" badge no longer appears in the view. The `(+N older)` count badge test remains unchanged.