### PR TITLE
fix: rename ACTION tab to ATTENTION

### DIFF
--- a/internal/tui/components/header/header.go
+++ b/internal/tui/components/header/header.go
@@ -84,7 +84,7 @@ func (m Model) View() string {
 		label string
 		count int
 	}{
-		{"attention", "ACTION", m.counts.Attention},
+		{"attention", "ATTENTION", m.counts.Attention},
 		{"active", "RUNNING", m.counts.Active},
 		{"completed", "DONE", m.counts.Completed},
 		{"failed", "FAILED", m.counts.Failed},

--- a/internal/tui/components/header/header_test.go
+++ b/internal/tui/components/header/header_test.go
@@ -82,7 +82,7 @@ func TestView_WithTabCounts(t *testing.T) {
 		t.Errorf("expected ALL count of 10, got: %s", view)
 	}
 	if !strings.Contains(view, "(3)") {
-		t.Errorf("expected ACTION count of 3, got: %s", view)
+		t.Errorf("expected ATTENTION count of 3, got: %s", view)
 	}
 }
 

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -58,7 +58,7 @@ func NewKeybindings() Keybindings {
 		),
 		FocusAttention: key.NewBinding(
 			key.WithKeys("a"),
-			key.WithHelp("a", "action view"),
+			key.WithHelp("a", "attention"),
 		),
 		ExitApp: key.NewBinding(
 			key.WithKeys("q", "ctrl+c"),


### PR DESCRIPTION
Renames the tab label from "ACTION" to "ATTENTION" and the `a` key hint from "action view" to "attention". Clearer intent — these are sessions that want your eyes.

Closes #98