### PR TITLE
feat: add live log tailing with follow mode for running sessions

### DIFF
--- a/internal/tui/components/logview/logview_test.go
+++ b/internal/tui/components/logview/logview_test.go
@@ -99,3 +99,94 @@ func TestView_NotReady(t *testing.T) {
 		t.Errorf("expected 'Loading logs...', got: %s", view)
 	}
 }
+
+func TestSetFollowMode_Toggle(t *testing.T) {
+	m := New(lipgloss.NewStyle(), 80, 24)
+	if m.FollowMode() {
+		t.Fatal("expected follow mode to be off by default")
+	}
+	m.SetFollowMode(true)
+	if !m.FollowMode() {
+		t.Fatal("expected follow mode to be on")
+	}
+	m.SetFollowMode(false)
+	if m.FollowMode() {
+		t.Fatal("expected follow mode to be off")
+	}
+}
+
+func TestSetLive(t *testing.T) {
+	m := New(lipgloss.NewStyle(), 80, 24)
+	if m.IsLive() {
+		t.Fatal("expected live to be off by default")
+	}
+	m.SetLive(true)
+	if !m.IsLive() {
+		t.Fatal("expected live to be on")
+	}
+	m.SetLive(false)
+	if m.IsLive() {
+		t.Fatal("expected live to be off")
+	}
+}
+
+func TestAppendOrReplace_UpdatesWhenLonger(t *testing.T) {
+	m := New(lipgloss.NewStyle(), 80, 24)
+	m.SetContent("short")
+	if m.rawContent != "short" {
+		t.Fatalf("expected rawContent 'short', got %q", m.rawContent)
+	}
+	m.AppendOrReplace("short and longer")
+	if m.rawContent != "short and longer" {
+		t.Fatalf("expected rawContent to be updated, got %q", m.rawContent)
+	}
+}
+
+func TestAppendOrReplace_NoUpdateWhenSameLength(t *testing.T) {
+	m := New(lipgloss.NewStyle(), 80, 24)
+	m.SetContent("hello")
+	m.AppendOrReplace("hello")
+	if m.rawContent != "hello" {
+		t.Fatalf("expected rawContent to remain 'hello', got %q", m.rawContent)
+	}
+}
+
+func TestAppendOrReplace_NoUpdateWhenShorter(t *testing.T) {
+	m := New(lipgloss.NewStyle(), 80, 24)
+	m.SetContent("longer content")
+	m.AppendOrReplace("short")
+	if m.rawContent != "longer content" {
+		t.Fatalf("expected rawContent to remain unchanged, got %q", m.rawContent)
+	}
+}
+
+func TestView_LiveFollowing(t *testing.T) {
+	m := New(lipgloss.NewStyle(), 80, 24)
+	m.SetContent("some log content")
+	m.SetLive(true)
+	m.SetFollowMode(true)
+	view := m.View()
+	if !strings.Contains(view, "LIVE 🔴") {
+		t.Errorf("expected LIVE indicator, got: %s", view)
+	}
+}
+
+func TestView_LivePaused(t *testing.T) {
+	m := New(lipgloss.NewStyle(), 80, 24)
+	m.SetContent("some log content")
+	m.SetLive(true)
+	m.SetFollowMode(false)
+	view := m.View()
+	if !strings.Contains(view, "PAUSED") {
+		t.Errorf("expected PAUSED indicator, got: %s", view)
+	}
+}
+
+func TestView_NotLive_NoIndicator(t *testing.T) {
+	m := New(lipgloss.NewStyle(), 80, 24)
+	m.SetContent("some log content")
+	view := m.View()
+	if strings.Contains(view, "LIVE") || strings.Contains(view, "PAUSED") {
+		t.Errorf("expected no indicator for non-live session, got: %s", view)
+	}
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -19,6 +19,7 @@ type Keybindings struct {
 	TogglePreview  key.Binding
 	GroupBy        key.Binding
 	ExpandGroup    key.Binding
+	ToggleFollow   key.Binding
 }
 
 // NewKeybindings creates the default key bindings for the TUI
@@ -83,6 +84,10 @@ func NewKeybindings() Keybindings {
 		ExpandGroup: key.NewBinding(
 			key.WithKeys(" "),
 			key.WithHelp("space", "expand/collapse"),
+		),
+		ToggleFollow: key.NewBinding(
+			key.WithKeys("f"),
+			key.WithHelp("f", "follow"),
 		),
 	}
 }

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -166,6 +166,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.taskList.SetAnimFrame(m.animFrame)
 		return m, m.animationTickCmd()
 
+	case logPollTickMsg:
+		if m.viewMode != ViewModeLog || !m.logView.IsLive() {
+			return m, nil
+		}
+		session := m.taskList.SelectedTask()
+		if session == nil {
+			return m, nil
+		}
+		return m, tea.Batch(m.fetchLogPoll(session.ID, session.Repository, session.Source), m.logPollTick())
+
+	case logPollResultMsg:
+		if msg.err == nil {
+			m.logView.AppendOrReplace(msg.log)
+		}
+		return m, nil
+
 	case errMsg:
 		m.ctx.Error = msg.err
 		return m, nil
@@ -273,6 +289,11 @@ func (m Model) handleListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		session := m.taskList.SelectedTask()
 		if session != nil {
 			m.viewMode = ViewModeLog
+			if isSessionRunning(session) {
+				m.logView.SetLive(true)
+				m.logView.SetFollowMode(true)
+				return m, tea.Batch(m.fetchTaskLog(session.ID, session.Repository), m.logPollTick())
+			}
 			return m, m.fetchTaskLog(session.ID, session.Repository)
 		}
 	case "o":
@@ -327,6 +348,11 @@ func (m Model) handleDetailKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		session := m.taskList.SelectedTask()
 		if session != nil {
 			m.viewMode = ViewModeLog
+			if isSessionRunning(session) {
+				m.logView.SetLive(true)
+				m.logView.SetFollowMode(true)
+				return m, tea.Batch(m.fetchTaskLog(session.ID, session.Repository), m.logPollTick())
+			}
 			return m, m.fetchTaskLog(session.ID, session.Repository)
 		}
 	case "o":
@@ -348,18 +374,31 @@ func (m Model) handleLogKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
 		m.viewMode = ViewModeList
+		m.logView.SetLive(false)
+		m.logView.SetFollowMode(false)
 	case "j", "down":
+		m.logView.SetFollowMode(false)
 		m.logView.LineDown()
 	case "k", "up":
+		m.logView.SetFollowMode(false)
 		m.logView.LineUp()
 	case "d":
+		m.logView.SetFollowMode(false)
 		m.logView.HalfPageDown()
 	case "u":
+		m.logView.SetFollowMode(false)
 		m.logView.HalfPageUp()
 	case "g":
+		m.logView.SetFollowMode(false)
 		m.logView.GotoTop()
 	case "G":
+		m.logView.SetFollowMode(true)
 		m.logView.GotoBottom()
+	case "f":
+		m.logView.SetFollowMode(!m.logView.FollowMode())
+		if m.logView.FollowMode() {
+			m.logView.GotoBottom()
+		}
 	case "s":
 		session := m.taskList.SelectedTask()
 		if session != nil {
@@ -402,6 +441,13 @@ type taskLogLoadedMsg struct {
 type refreshTickMsg struct{}
 
 type animationTickMsg struct{}
+
+type logPollTickMsg struct{}
+
+type logPollResultMsg struct {
+	log string
+	err error
+}
 
 type errMsg struct {
 	err error
@@ -552,6 +598,29 @@ func (m Model) resumeSession(session *data.Session) tea.Cmd {
 	})
 }
 
+func (m Model) logPollTick() tea.Cmd {
+	return tea.Tick(2*time.Second, func(t time.Time) tea.Msg {
+		return logPollTickMsg{}
+	})
+}
+
+func (m Model) fetchLogPoll(id string, repo string, source data.SessionSource) tea.Cmd {
+	return func() tea.Msg {
+		var log string
+		var err error
+		if source == data.SourceLocalCopilot {
+			log, err = data.FetchLocalSessionLog(id)
+		} else {
+			log, err = data.FetchAgentTaskLog(id, repo)
+		}
+		return logPollResultMsg{log: log, err: err}
+	}
+}
+
+func isSessionRunning(session *data.Session) bool {
+	return session != nil && data.StatusIsActive(session.Status)
+}
+
 func (m Model) refreshCmd() tea.Cmd {
 	return tea.Tick(m.refreshInt, func(time.Time) tea.Msg {
 		return refreshTickMsg{}
@@ -652,6 +721,9 @@ func (m *Model) updateFooterHints() {
 			key.NewBinding(key.WithKeys("g/G"), key.WithHelp("g/G", "top/bottom")),
 		}
 		selected := m.taskList.SelectedTask()
+		if m.logView.IsLive() {
+			logHints = append(logHints, m.keys.ToggleFollow)
+		}
 		if canResumeLocalSession(selected) {
 			logHints = append(logHints, m.keys.ResumeSession)
 		}


### PR DESCRIPTION
## Summary

Implements poll-based live log tailing for running agent sessions.

Closes #63

## Changes

### Logview component (`internal/tui/components/logview/logview.go`)
- Added `followMode` and `liveSession` fields with getters/setters
- Added `AppendOrReplace()` method: updates content only when new log is longer (poll-and-replace strategy), auto-scrolls when follow mode is on
- Updated `View()` to show **LIVE 🔴** indicator when following, **PAUSED ⏸** when scrolled away

### UI layer (`internal/tui/ui.go`)
- Added `logPollTickMsg` and `logPollResultMsg` message types
- 2-second poll loop re-fetches logs for running sessions via `fetchLogPoll()`
- Entering log view for a running session enables live + follow mode and starts polling
- Polling stops when leaving log view or when session is not live
- Scroll-up keys (j/k/u/d/g) auto-pause follow mode
- `G` (goto bottom) re-enables follow mode
- `f` key toggles follow mode
- `esc` clears live/follow state

### Keys (`internal/tui/keys.go`)
- Added `ToggleFollow` binding (`f` key, help: "follow")
- Footer hints show follow key when in live log view

### Tests
- Logview: toggle follow, toggle live, AppendOrReplace update/no-update, View indicators
- UI: `f` key toggle, scroll-up pauses follow, `G` enables follow, `esc` clears live mode, `isSessionRunning` helper