### PR TITLE
feat: add session timeline bar in detail view

### DIFF
--- a/internal/tui/components/taskdetail/taskdetail.go
+++ b/internal/tui/components/taskdetail/taskdetail.go
@@ -57,6 +57,10 @@ func (m Model) View() string {
 		fmt.Sprintf("Session ID: %s", m.session.ID),
 	)
 
+	if tl := RenderTimeline(m.session, timelineWidth(m.width)); tl != "" {
+		details = append(details, "", fmt.Sprintf("Timeline:   %s", tl))
+	}
+
 	// Show telemetry if available
 	if m.session.Telemetry != nil {
 		t := m.session.Telemetry
@@ -135,6 +139,10 @@ func (m Model) ViewSplit() string {
 		fmt.Sprintf("Updated:    %s", detailTimestamp(m.session.UpdatedAt)),
 		fmt.Sprintf("Session ID: %s", m.session.ID),
 	)
+
+	if tl := RenderTimeline(m.session, timelineWidth(m.width)); tl != "" {
+		details = append(details, "", fmt.Sprintf("Timeline:   %s", tl))
+	}
 
 	if m.session.Telemetry != nil {
 		t := m.session.Telemetry
@@ -219,4 +227,21 @@ func formatDuration(d time.Duration) string {
 		return fmt.Sprintf("%dh %dm", hours, minutes)
 	}
 	return fmt.Sprintf("%dh", hours)
+}
+
+// timelineWidth picks a reasonable bar width based on available space.
+func timelineWidth(availableWidth int) int {
+	const defaultWidth = 24
+	if availableWidth <= 0 {
+		return defaultWidth
+	}
+	// Leave room for "Timeline:   " prefix (12) + "  Xh ago → now" suffix (~16)
+	w := availableWidth - 28
+	if w < 8 {
+		return 8
+	}
+	if w > 48 {
+		return 48
+	}
+	return w
 }

--- a/internal/tui/components/taskdetail/timeline.go
+++ b/internal/tui/components/taskdetail/timeline.go
@@ -1,0 +1,97 @@
+package taskdetail
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/maxbeizer/gh-agent-viz/internal/data"
+)
+
+const (
+	blockIdle   = '░'
+	blockInact  = '▒'
+	blockActive = '▓'
+	blockFull   = '█'
+)
+
+// nowFunc is overridable for testing.
+var nowFunc = time.Now
+
+// RenderTimeline returns a Unicode timeline bar showing the session lifecycle.
+// The bar uses ░ (idle/pre-creation), ▒ (created but inactive), ▓ (active), █ (current activity).
+// width is the character width of the bar (typically 24-32 chars).
+func RenderTimeline(session *data.Session, width int) string {
+	if session == nil || session.CreatedAt.IsZero() || width < 1 {
+		return ""
+	}
+
+	now := nowFunc()
+	created := session.CreatedAt
+	updated := session.UpdatedAt
+
+	if created.After(now) {
+		created = now
+	}
+
+	totalSpan := now.Sub(created)
+	if totalSpan <= 0 {
+		// Session just created — show a single block for current state
+		bar := strings.Repeat(string(blockChar(session.Status)), width)
+		return fmt.Sprintf("%s  %s → now", bar, formatRelative(totalSpan))
+	}
+
+	// Determine the active window: from created to updated (or created if no update)
+	activeEnd := created
+	if !updated.IsZero() && updated.After(created) {
+		activeEnd = updated
+		if activeEnd.After(now) {
+			activeEnd = now
+		}
+	}
+
+	bar := make([]rune, width)
+	for i := range bar {
+		// Map character position to a point in time
+		posTime := created.Add(totalSpan * time.Duration(i) / time.Duration(width))
+
+		if posTime.Before(activeEnd) || posTime.Equal(activeEnd) {
+			if data.StatusIsActive(session.Status) {
+				bar[i] = blockFull
+			} else {
+				bar[i] = blockActive
+			}
+		} else {
+			bar[i] = blockIdle
+		}
+	}
+
+	// Mark the right edge based on current status
+	if data.StatusIsActive(session.Status) {
+		bar[width-1] = blockFull
+	}
+
+	return fmt.Sprintf("%s  %s → now", string(bar), formatRelative(totalSpan))
+}
+
+func blockChar(status string) rune {
+	if data.StatusIsActive(status) {
+		return blockFull
+	}
+	return blockActive
+}
+
+func formatRelative(d time.Duration) string {
+	if d < time.Minute {
+		return "<1m ago"
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	}
+	hours := int(d.Hours())
+	if hours < 24 {
+		return fmt.Sprintf("%dh ago", hours)
+	}
+	days := hours / 24
+	return fmt.Sprintf("%dd ago", days)
+}

--- a/internal/tui/components/taskdetail/timeline_test.go
+++ b/internal/tui/components/taskdetail/timeline_test.go
@@ -1,0 +1,221 @@
+package taskdetail
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/maxbeizer/gh-agent-viz/internal/data"
+)
+
+func withFrozenNow(t time.Time, fn func()) {
+	orig := nowFunc
+	nowFunc = func() time.Time { return t }
+	defer func() { nowFunc = orig }()
+	fn()
+}
+
+func TestRenderTimeline_NilSession(t *testing.T) {
+	got := RenderTimeline(nil, 24)
+	if got != "" {
+		t.Errorf("expected empty string for nil session, got %q", got)
+	}
+}
+
+func TestRenderTimeline_ZeroCreatedAt(t *testing.T) {
+	s := &data.Session{Status: "running"}
+	got := RenderTimeline(s, 24)
+	if got != "" {
+		t.Errorf("expected empty string for zero CreatedAt, got %q", got)
+	}
+}
+
+func TestRenderTimeline_ZeroWidth(t *testing.T) {
+	s := &data.Session{
+		Status:    "running",
+		CreatedAt: time.Now().Add(-time.Hour),
+	}
+	got := RenderTimeline(s, 0)
+	if got != "" {
+		t.Errorf("expected empty string for zero width, got %q", got)
+	}
+}
+
+func TestRenderTimeline_RunningSession(t *testing.T) {
+	now := time.Date(2025, 1, 10, 12, 0, 0, 0, time.UTC)
+	s := &data.Session{
+		Status:    "running",
+		CreatedAt: now.Add(-2 * time.Hour),
+		UpdatedAt: now.Add(-30 * time.Minute),
+	}
+
+	withFrozenNow(now, func() {
+		got := RenderTimeline(s, 24)
+		if got == "" {
+			t.Fatal("expected non-empty timeline")
+		}
+		// Should contain block characters
+		if !strings.ContainsRune(got, blockFull) {
+			t.Errorf("expected █ in running session timeline, got %q", got)
+		}
+		if !strings.ContainsRune(got, blockIdle) {
+			t.Errorf("expected ░ in timeline with idle period, got %q", got)
+		}
+		if !strings.Contains(got, "→ now") {
+			t.Errorf("expected '→ now' label, got %q", got)
+		}
+		// Right edge should be █ for active session
+		bar := strings.Split(got, "  ")[0]
+		runes := []rune(bar)
+		if runes[len(runes)-1] != blockFull {
+			t.Errorf("expected right edge to be █ for running session, got %c", runes[len(runes)-1])
+		}
+	})
+}
+
+func TestRenderTimeline_CompletedSession(t *testing.T) {
+	now := time.Date(2025, 1, 10, 12, 0, 0, 0, time.UTC)
+	s := &data.Session{
+		Status:    "completed",
+		CreatedAt: now.Add(-4 * time.Hour),
+		UpdatedAt: now.Add(-2 * time.Hour),
+	}
+
+	withFrozenNow(now, func() {
+		got := RenderTimeline(s, 24)
+		if got == "" {
+			t.Fatal("expected non-empty timeline")
+		}
+		if !strings.ContainsRune(got, blockActive) {
+			t.Errorf("expected ▓ in completed session timeline, got %q", got)
+		}
+		if !strings.ContainsRune(got, blockIdle) {
+			t.Errorf("expected ░ in completed session with idle tail, got %q", got)
+		}
+		if !strings.Contains(got, "4h ago") {
+			t.Errorf("expected '4h ago' label, got %q", got)
+		}
+	})
+}
+
+func TestRenderTimeline_VeryShortSession(t *testing.T) {
+	now := time.Date(2025, 1, 10, 12, 0, 0, 0, time.UTC)
+	s := &data.Session{
+		Status:    "running",
+		CreatedAt: now.Add(-10 * time.Second),
+		UpdatedAt: now.Add(-5 * time.Second),
+	}
+
+	withFrozenNow(now, func() {
+		got := RenderTimeline(s, 24)
+		if got == "" {
+			t.Fatal("expected non-empty timeline for short session")
+		}
+		if !strings.Contains(got, "<1m ago") {
+			t.Errorf("expected '<1m ago' for short session, got %q", got)
+		}
+	})
+}
+
+func TestRenderTimeline_JustCreated(t *testing.T) {
+	now := time.Date(2025, 1, 10, 12, 0, 0, 0, time.UTC)
+	s := &data.Session{
+		Status:    "running",
+		CreatedAt: now,
+	}
+
+	withFrozenNow(now, func() {
+		got := RenderTimeline(s, 16)
+		if got == "" {
+			t.Fatal("expected non-empty timeline for just-created session")
+		}
+		bar := strings.Split(got, "  ")[0]
+		if len([]rune(bar)) != 16 {
+			t.Errorf("expected bar width 16, got %d", len([]rune(bar)))
+		}
+	})
+}
+
+func TestRenderTimeline_NarrowWidth(t *testing.T) {
+	now := time.Date(2025, 1, 10, 12, 0, 0, 0, time.UTC)
+	s := &data.Session{
+		Status:    "completed",
+		CreatedAt: now.Add(-1 * time.Hour),
+		UpdatedAt: now.Add(-30 * time.Minute),
+	}
+
+	withFrozenNow(now, func() {
+		got := RenderTimeline(s, 4)
+		if got == "" {
+			t.Fatal("expected non-empty timeline for narrow width")
+		}
+		bar := strings.Split(got, "  ")[0]
+		if len([]rune(bar)) != 4 {
+			t.Errorf("expected bar width 4, got %d", len([]rune(bar)))
+		}
+	})
+}
+
+func TestRenderTimeline_WideWidth(t *testing.T) {
+	now := time.Date(2025, 1, 10, 12, 0, 0, 0, time.UTC)
+	s := &data.Session{
+		Status:    "running",
+		CreatedAt: now.Add(-3 * time.Hour),
+		UpdatedAt: now.Add(-1 * time.Hour),
+	}
+
+	withFrozenNow(now, func() {
+		got := RenderTimeline(s, 80)
+		if got == "" {
+			t.Fatal("expected non-empty timeline for wide width")
+		}
+		bar := strings.Split(got, "  ")[0]
+		if len([]rune(bar)) != 80 {
+			t.Errorf("expected bar width 80, got %d", len([]rune(bar)))
+		}
+	})
+}
+
+func TestRenderTimeline_OnlyCreatedNoUpdated(t *testing.T) {
+	now := time.Date(2025, 1, 10, 12, 0, 0, 0, time.UTC)
+	s := &data.Session{
+		Status:    "queued",
+		CreatedAt: now.Add(-30 * time.Minute),
+	}
+
+	withFrozenNow(now, func() {
+		got := RenderTimeline(s, 24)
+		if got == "" {
+			t.Fatal("expected non-empty timeline for session with only CreatedAt")
+		}
+		// All chars except right edge should be idle since activeEnd == created
+		bar := strings.Split(got, "  ")[0]
+		runes := []rune(bar)
+		// First char maps to created time (position 0 == created), should be active
+		// since posTime == activeEnd == created
+		if runes[0] != blockFull {
+			t.Errorf("expected first char to be █ (at created time), got %c", runes[0])
+		}
+	})
+}
+
+func TestFormatRelative(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Second, "<1m ago"},
+		{5 * time.Minute, "5m ago"},
+		{90 * time.Minute, "1h ago"},
+		{2 * time.Hour, "2h ago"},
+		{25 * time.Hour, "1d ago"},
+		{48 * time.Hour, "2d ago"},
+	}
+
+	for _, tt := range tests {
+		got := formatRelative(tt.d)
+		if got != tt.want {
+			t.Errorf("formatRelative(%v) = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Adds a horizontal Unicode timeline bar showing session lifecycle phases (created → active → idle → now) using block characters (░▒▓█).

Displayed in both full-screen and split-pane detail views when CreatedAt is available.

Closes #62