### PR TITLE
feat: add session dependency graph in detail view

### DIFF
--- a/internal/tui/components/taskdetail/depgraph.go
+++ b/internal/tui/components/taskdetail/depgraph.go
@@ -1,0 +1,178 @@
+package taskdetail
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/maxbeizer/gh-agent-viz/internal/data"
+)
+
+// DepNode represents a node in the dependency graph
+type DepNode struct {
+	Label string // e.g., "PR #42", "Issue #15", session title
+	URL   string // for potential browser opening
+}
+
+// DepEdge represents a directed relationship
+type DepEdge struct {
+	From int // index into nodes
+	To   int // index into nodes
+}
+
+// DepGraph holds the parsed dependency information
+type DepGraph struct {
+	Nodes []DepNode
+	Edges []DepEdge
+}
+
+// ParseSessionDeps extracts dependency information from a session.
+// Looks for PR references, issue references in the title/branch.
+func ParseSessionDeps(session *data.Session, allSessions []data.Session) *DepGraph {
+	if session == nil || len(allSessions) == 0 {
+		return &DepGraph{}
+	}
+
+	graph := &DepGraph{}
+
+	// Add the current session as the first node
+	currentLabel := sessionLabel(session)
+	graph.Nodes = append(graph.Nodes, DepNode{
+		Label: currentLabel,
+		URL:   session.PRURL,
+	})
+
+	currentIdx := 0
+	repo := strings.TrimSpace(session.Repository)
+	branch := strings.TrimSpace(session.Branch)
+	branchPrefix := branchGroupPrefix(branch)
+
+	for i := range allSessions {
+		other := &allSessions[i]
+		if other.ID == session.ID {
+			continue
+		}
+
+		related := false
+
+		// Same repository with related branch prefix
+		otherRepo := strings.TrimSpace(other.Repository)
+		otherBranch := strings.TrimSpace(other.Branch)
+		if repo != "" && otherRepo != "" && repo == otherRepo {
+			if branchPrefix != "" && branchGroupPrefix(otherBranch) == branchPrefix {
+				related = true
+			}
+		}
+
+		if !related {
+			continue
+		}
+
+		otherLabel := sessionLabel(other)
+		otherIdx := len(graph.Nodes)
+		graph.Nodes = append(graph.Nodes, DepNode{
+			Label: otherLabel,
+			URL:   other.PRURL,
+		})
+		graph.Edges = append(graph.Edges, DepEdge{
+			From: currentIdx,
+			To:   otherIdx,
+		})
+	}
+
+	return graph
+}
+
+// RenderDepGraph renders a dependency graph using box-drawing characters.
+// Returns empty string if graph has no meaningful relationships.
+func RenderDepGraph(graph *DepGraph, width int) string {
+	if graph == nil || len(graph.Edges) == 0 {
+		return ""
+	}
+
+	maxLabelWidth := width - 10
+	if maxLabelWidth < 10 {
+		maxLabelWidth = 10
+	}
+
+	// Collect targets for the current (first) node
+	targets := []int{}
+	for _, e := range graph.Edges {
+		if e.From == 0 {
+			targets = append(targets, e.To)
+		}
+	}
+
+	if len(targets) == 0 {
+		return ""
+	}
+
+	fromLabel := truncateLabel(graph.Nodes[0].Label, maxLabelWidth)
+
+	var lines []string
+	if len(targets) == 1 {
+		toLabel := truncateLabel(graph.Nodes[targets[0]].Label, maxLabelWidth)
+		lines = append(lines, fmt.Sprintf("  %s ──→ %s", fromLabel, toLabel))
+	} else {
+		// First target uses direct arrow
+		toLabel := truncateLabel(graph.Nodes[targets[0]].Label, maxLabelWidth)
+		lines = append(lines, fmt.Sprintf("  %s ──→ %s", fromLabel, toLabel))
+		// Remaining targets use tree connectors
+		padding := strings.Repeat(" ", len(fromLabel)+2)
+		for i := 1; i < len(targets); i++ {
+			toLabel = truncateLabel(graph.Nodes[targets[i]].Label, maxLabelWidth)
+			connector := "├──"
+			if i == len(targets)-1 {
+				connector = "└──"
+			}
+			lines = append(lines, fmt.Sprintf("%s%s→ %s", padding, connector, toLabel))
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// sessionLabel returns a display label for a session node.
+func sessionLabel(s *data.Session) string {
+	if s.PRNumber > 0 {
+		return fmt.Sprintf("PR #%d", s.PRNumber)
+	}
+	title := strings.TrimSpace(s.Title)
+	if title != "" {
+		return title
+	}
+	return s.ID
+}
+
+// branchGroupPrefix extracts a grouping prefix from a branch name.
+// e.g., "feature/auth-bug" → "feature/auth", "fix/login-flow" → "fix/login"
+func branchGroupPrefix(branch string) string {
+	branch = strings.TrimSpace(branch)
+	if branch == "" || branch == "main" || branch == "master" {
+		return ""
+	}
+
+	// Split on last hyphen to get the prefix group
+	idx := strings.LastIndex(branch, "-")
+	if idx > 0 {
+		return branch[:idx]
+	}
+
+	// Split on last slash segment if no hyphen
+	idx = strings.LastIndex(branch, "/")
+	if idx > 0 {
+		return branch[:idx]
+	}
+
+	return branch
+}
+
+// truncateLabel shortens a label to fit within maxWidth, adding ellipsis.
+func truncateLabel(label string, maxWidth int) string {
+	if len(label) <= maxWidth {
+		return label
+	}
+	if maxWidth <= 3 {
+		return label[:maxWidth]
+	}
+	return label[:maxWidth-3] + "..."
+}

--- a/internal/tui/components/taskdetail/depgraph_test.go
+++ b/internal/tui/components/taskdetail/depgraph_test.go
@@ -1,0 +1,190 @@
+package taskdetail
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/maxbeizer/gh-agent-viz/internal/data"
+)
+
+func TestParseSessionDeps_NoRelationships(t *testing.T) {
+	session := &data.Session{
+		ID:         "s1",
+		Title:      "Fix auth bug",
+		Repository: "github/app",
+		Branch:     "feature/auth-bug",
+	}
+	others := []data.Session{
+		{ID: "s2", Title: "Update docs", Repository: "github/docs", Branch: "main"},
+	}
+
+	graph := ParseSessionDeps(session, others)
+	rendered := RenderDepGraph(graph, 80)
+	if rendered != "" {
+		t.Fatalf("expected empty render for unrelated sessions, got: %q", rendered)
+	}
+}
+
+func TestParseSessionDeps_NilSession(t *testing.T) {
+	graph := ParseSessionDeps(nil, []data.Session{})
+	rendered := RenderDepGraph(graph, 80)
+	if rendered != "" {
+		t.Fatalf("expected empty render for nil session, got: %q", rendered)
+	}
+}
+
+func TestParseSessionDeps_SinglePRReference(t *testing.T) {
+	session := &data.Session{
+		ID:         "s1",
+		PRNumber:   42,
+		Repository: "github/app",
+		Branch:     "feature/auth-bug",
+	}
+	others := []data.Session{
+		{ID: "s2", PRNumber: 43, Repository: "github/app", Branch: "feature/auth-tests"},
+	}
+
+	graph := ParseSessionDeps(session, others)
+	rendered := RenderDepGraph(graph, 80)
+	if !strings.Contains(rendered, "PR #42") {
+		t.Fatalf("expected PR #42 in render, got: %q", rendered)
+	}
+	if !strings.Contains(rendered, "PR #43") {
+		t.Fatalf("expected PR #43 in render, got: %q", rendered)
+	}
+	if !strings.Contains(rendered, "──→") {
+		t.Fatalf("expected arrow in render, got: %q", rendered)
+	}
+}
+
+func TestParseSessionDeps_LinearChain(t *testing.T) {
+	session := &data.Session{
+		ID:         "s1",
+		PRNumber:   42,
+		Repository: "github/app",
+		Branch:     "feature/auth-bug",
+	}
+	others := []data.Session{
+		{ID: "s1", PRNumber: 42, Repository: "github/app", Branch: "feature/auth-bug"},
+		{ID: "s2", PRNumber: 43, Repository: "github/app", Branch: "feature/auth-tests"},
+		{ID: "s3", PRNumber: 44, Repository: "github/app", Branch: "feature/auth-docs"},
+	}
+
+	graph := ParseSessionDeps(session, others)
+	rendered := RenderDepGraph(graph, 80)
+	if !strings.Contains(rendered, "PR #42") {
+		t.Fatalf("expected PR #42 in render, got: %q", rendered)
+	}
+	if !strings.Contains(rendered, "PR #43") {
+		t.Fatalf("expected PR #43 in render, got: %q", rendered)
+	}
+	if !strings.Contains(rendered, "PR #44") {
+		t.Fatalf("expected PR #44 in render, got: %q", rendered)
+	}
+}
+
+func TestParseSessionDeps_FanOut(t *testing.T) {
+	session := &data.Session{
+		ID:         "s1",
+		Title:      "Fix auth bug",
+		PRNumber:   42,
+		Repository: "github/app",
+		Branch:     "feature/auth-bug",
+	}
+	others := []data.Session{
+		{ID: "s2", Title: "Add auth tests", PRNumber: 43, Repository: "github/app", Branch: "feature/auth-tests"},
+		{ID: "s3", Title: "Update docs", PRNumber: 44, Repository: "github/app", Branch: "feature/auth-docs"},
+		{ID: "s4", Title: "Auth cleanup", PRNumber: 45, Repository: "github/app", Branch: "feature/auth-cleanup"},
+	}
+
+	graph := ParseSessionDeps(session, others)
+	rendered := RenderDepGraph(graph, 80)
+
+	if !strings.Contains(rendered, "PR #42") {
+		t.Fatalf("expected PR #42 in render, got: %q", rendered)
+	}
+	// Should have tree connectors for fan-out
+	if !strings.Contains(rendered, "├──") {
+		t.Fatalf("expected ├── connector in fan-out render, got: %q", rendered)
+	}
+	if !strings.Contains(rendered, "└──") {
+		t.Fatalf("expected └── connector in fan-out render, got: %q", rendered)
+	}
+}
+
+func TestTruncateLabel(t *testing.T) {
+	tests := []struct {
+		label    string
+		maxWidth int
+		want     string
+	}{
+		{"short", 10, "short"},
+		{"a very long label that exceeds", 15, "a very long ..."},
+		{"abc", 3, "abc"},
+		{"abcd", 3, "abc"},
+	}
+
+	for _, tt := range tests {
+		got := truncateLabel(tt.label, tt.maxWidth)
+		if got != tt.want {
+			t.Errorf("truncateLabel(%q, %d) = %q, want %q", tt.label, tt.maxWidth, got, tt.want)
+		}
+	}
+}
+
+func TestRenderDepGraph_EmptyGraph(t *testing.T) {
+	graph := &DepGraph{}
+	rendered := RenderDepGraph(graph, 80)
+	if rendered != "" {
+		t.Fatalf("expected empty string for empty graph, got: %q", rendered)
+	}
+}
+
+func TestRenderDepGraph_NilGraph(t *testing.T) {
+	rendered := RenderDepGraph(nil, 80)
+	if rendered != "" {
+		t.Fatalf("expected empty string for nil graph, got: %q", rendered)
+	}
+}
+
+func TestBranchGroupPrefix(t *testing.T) {
+	tests := []struct {
+		branch string
+		want   string
+	}{
+		{"feature/auth-bug", "feature/auth"},
+		{"feature/auth-tests", "feature/auth"},
+		{"fix/login-flow", "fix/login"},
+		{"main", ""},
+		{"master", ""},
+		{"", ""},
+		{"feature/auth", "feature"},
+		{"simple", "simple"},
+	}
+
+	for _, tt := range tests {
+		got := branchGroupPrefix(tt.branch)
+		if got != tt.want {
+			t.Errorf("branchGroupPrefix(%q) = %q, want %q", tt.branch, got, tt.want)
+		}
+	}
+}
+
+func TestSessionLabel(t *testing.T) {
+	tests := []struct {
+		session *data.Session
+		want    string
+	}{
+		{&data.Session{PRNumber: 42}, "PR #42"},
+		{&data.Session{Title: "Fix bug"}, "Fix bug"},
+		{&data.Session{ID: "abc-123"}, "abc-123"},
+		{&data.Session{PRNumber: 10, Title: "Some title"}, "PR #10"},
+	}
+
+	for _, tt := range tests {
+		got := sessionLabel(tt.session)
+		if got != tt.want {
+			t.Errorf("sessionLabel(%+v) = %q, want %q", tt.session, got, tt.want)
+		}
+	}
+}

--- a/internal/tui/components/taskdetail/taskdetail.go
+++ b/internal/tui/components/taskdetail/taskdetail.go
@@ -14,6 +14,7 @@ type Model struct {
 	titleStyle  lipgloss.Style
 	borderStyle lipgloss.Style
 	session     *data.Session
+	allSessions []data.Session
 	statusIcon  func(string) string
 	width       int
 	height      int
@@ -75,12 +76,23 @@ func (m Model) View() string {
 		}
 	}
 
+	// Show dependency graph if relationships exist
+	graph := ParseSessionDeps(m.session, m.allSessions)
+	if rendered := RenderDepGraph(graph, m.width); rendered != "" {
+		details = append(details, "", m.titleStyle.Render("Related Sessions"), rendered)
+	}
+
 	return m.borderStyle.Render(joinVertical(details))
 }
 
 // SetTask updates the session being displayed
 func (m *Model) SetTask(session *data.Session) {
 	m.session = session
+}
+
+// SetAllSessions updates the full session list for dependency graph rendering.
+func (m *Model) SetAllSessions(sessions []data.Session) {
+	m.allSessions = sessions
 }
 
 // SetSize updates the available rendering size for responsive layout.
@@ -151,6 +163,12 @@ func (m Model) ViewSplit() string {
 		if t.ConversationTurns == 0 && t.Duration == 0 {
 			details = append(details, "No usage data available")
 		}
+	}
+
+	// Show dependency graph if relationships exist
+	graph := ParseSessionDeps(m.session, m.allSessions)
+	if rendered := RenderDepGraph(graph, m.width); rendered != "" {
+		details = append(details, "", m.titleStyle.Render("Related Sessions"), rendered)
 	}
 
 	style := lipgloss.NewStyle().

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -146,6 +146,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		})
 		m.taskList.SetLoading(false)
 		m.taskList.SetTasks(msg.tasks)
+		m.taskDetail.SetAllSessions(msg.tasks)
 		return m, nil
 
 	case taskDetailLoadedMsg:


### PR DESCRIPTION
Adds a mini dependency graph in the detail view showing relationships between sessions that share repositories or branch prefixes.

- Uses box-drawing characters (──→, └──, ├──) for rendering
- Parses PR references and branch relationships
- Hidden when no relationships exist
- Displayed in both full-screen and split-pane detail views

Closes #66