### PR TITLE
feat: add kanban view mode with status columns

### DIFF
--- a/internal/tui/components/kanban/kanban.go
+++ b/internal/tui/components/kanban/kanban.go
@@ -1,0 +1,371 @@
+package kanban
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/maxbeizer/gh-agent-viz/internal/data"
+)
+
+// Column represents a status column in the kanban board
+type Column struct {
+	Title    string
+	Status   string // status key used in column header
+	Sessions []data.Session
+}
+
+// defaultColumns returns the fixed set of kanban columns.
+func defaultColumns() []Column {
+	return []Column{
+		{Title: "RUNNING", Status: "running"},
+		{Title: "NEEDS INPUT", Status: "needs-input"},
+		{Title: "COMPLETED", Status: "completed"},
+		{Title: "FAILED", Status: "failed"},
+	}
+}
+
+// statusBelongsToColumn returns true when a session status belongs in the given column.
+func statusBelongsToColumn(sessionStatus, colStatus string) bool {
+	s := strings.ToLower(strings.TrimSpace(sessionStatus))
+	switch colStatus {
+	case "running":
+		return s == "running" || s == "active" || s == "queued"
+	case "needs-input":
+		return s == "needs-input"
+	case "completed":
+		return s == "completed"
+	case "failed":
+		return s == "failed"
+	}
+	return false
+}
+
+// Model represents the kanban board state
+type Model struct {
+	columns           []Column
+	colCursor         int
+	rowCursor         int
+	statusIcon        func(string) string
+	animStatusIcon    func(string, int) string
+	animFrame         int
+	width             int
+	height            int
+	titleStyle        lipgloss.Style
+	columnStyle       lipgloss.Style
+	cardStyle         lipgloss.Style
+	cardSelectedStyle lipgloss.Style
+}
+
+// New creates a new kanban board model.
+func New(
+	titleStyle lipgloss.Style,
+	borderStyle lipgloss.Style,
+	rowStyle lipgloss.Style,
+	rowSelectedStyle lipgloss.Style,
+	statusIconFunc func(string) string,
+	animStatusIconFunc func(string, int) string,
+) Model {
+	return Model{
+		columns:           defaultColumns(),
+		statusIcon:        statusIconFunc,
+		animStatusIcon:    animStatusIconFunc,
+		titleStyle:        titleStyle,
+		columnStyle:       borderStyle,
+		cardStyle:         rowStyle,
+		cardSelectedStyle: rowSelectedStyle,
+		width:             80,
+		height:            24,
+	}
+}
+
+// SetSessions distributes sessions into columns by status.
+func (m *Model) SetSessions(sessions []data.Session) {
+	cols := defaultColumns()
+	for i := range cols {
+		cols[i].Sessions = nil
+	}
+	for _, s := range sessions {
+		for i := range cols {
+			if statusBelongsToColumn(s.Status, cols[i].Status) {
+				cols[i].Sessions = append(cols[i].Sessions, s)
+				break
+			}
+		}
+	}
+	m.columns = cols
+	// Clamp cursors
+	m.clampCursors()
+}
+
+// MoveColumn moves the column cursor by delta (negative = left, positive = right).
+func (m *Model) MoveColumn(delta int) {
+	if len(m.columns) == 0 {
+		return
+	}
+	m.colCursor += delta
+	if m.colCursor < 0 {
+		m.colCursor = 0
+	}
+	if m.colCursor >= len(m.columns) {
+		m.colCursor = len(m.columns) - 1
+	}
+	// Clamp row cursor to new column
+	m.clampRowCursor()
+}
+
+// MoveRow moves the row cursor within the current column by delta.
+func (m *Model) MoveRow(delta int) {
+	col := m.currentColumn()
+	if col == nil || len(col.Sessions) == 0 {
+		return
+	}
+	m.rowCursor += delta
+	if m.rowCursor < 0 {
+		m.rowCursor = 0
+	}
+	if m.rowCursor >= len(col.Sessions) {
+		m.rowCursor = len(col.Sessions) - 1
+	}
+}
+
+// SelectedSession returns a pointer to the currently focused session, or nil.
+func (m *Model) SelectedSession() *data.Session {
+	col := m.currentColumn()
+	if col == nil || len(col.Sessions) == 0 {
+		return nil
+	}
+	if m.rowCursor < 0 || m.rowCursor >= len(col.Sessions) {
+		return nil
+	}
+	s := col.Sessions[m.rowCursor]
+	return &s
+}
+
+// SetSize sets the available dimensions for rendering.
+func (m *Model) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+}
+
+// SetAnimFrame updates the animation frame counter.
+func (m *Model) SetAnimFrame(frame int) {
+	m.animFrame = frame
+}
+
+// Columns returns the current columns (for testing).
+func (m *Model) Columns() []Column {
+	return m.columns
+}
+
+// ColCursor returns the current column cursor position (for testing).
+func (m *Model) ColCursor() int {
+	return m.colCursor
+}
+
+// RowCursor returns the current row cursor position (for testing).
+func (m *Model) RowCursor() int {
+	return m.rowCursor
+}
+
+// ColumnWidth computes the width for each column based on non-empty column count.
+func (m *Model) ColumnWidth() int {
+	nonEmpty := 0
+	for _, col := range m.columns {
+		if len(col.Sessions) > 0 {
+			nonEmpty++
+		}
+	}
+	count := len(m.columns)
+	if nonEmpty > 0 {
+		count = nonEmpty
+	}
+	// Always show all columns, but size based on visible count
+	count = len(m.columns)
+	if count == 0 {
+		return m.width
+	}
+	// Account for gaps between columns (1 space each)
+	gaps := count - 1
+	available := m.width - gaps
+	w := available / count
+	if w < 20 {
+		w = 20
+	}
+	return w
+}
+
+// View renders the full kanban board.
+func (m *Model) View() string {
+	colWidth := m.ColumnWidth()
+	// Available height for cards inside a column (subtract header/border chrome)
+	// Border top + title line + border bottom = 3 lines of chrome
+	cardAreaHeight := m.height - 6
+	if cardAreaHeight < 3 {
+		cardAreaHeight = 3
+	}
+
+	columnViews := make([]string, len(m.columns))
+	for i, col := range m.columns {
+		isFocusedCol := (i == m.colCursor)
+		columnViews[i] = m.renderColumn(col, i, colWidth, cardAreaHeight, isFocusedCol)
+	}
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, columnViews...)
+}
+
+// renderColumn renders a single kanban column.
+func (m *Model) renderColumn(col Column, colIdx, width, cardAreaHeight int, focused bool) string {
+	innerWidth := width - 4 // account for border left/right + padding
+	if innerWidth < 10 {
+		innerWidth = 10
+	}
+
+	// Build card lines
+	var cardLines []string
+	if len(col.Sessions) == 0 {
+		placeholder := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("241")).
+			Italic(true).
+			Render("(no sessions)")
+		cardLines = append(cardLines, placeholder)
+	} else {
+		for rowIdx, session := range col.Sessions {
+			isSelected := focused && rowIdx == m.rowCursor
+			card := m.renderCard(session, innerWidth, isSelected)
+			cardLines = append(cardLines, card)
+		}
+	}
+
+	content := strings.Join(cardLines, "\n")
+
+	// Pad or truncate to fill card area height
+	lines := strings.Split(content, "\n")
+	for len(lines) < cardAreaHeight {
+		lines = append(lines, strings.Repeat(" ", innerWidth))
+	}
+	if len(lines) > cardAreaHeight {
+		lines = lines[:cardAreaHeight]
+	}
+	content = strings.Join(lines, "\n")
+
+	// Build title with column header
+	title := fmt.Sprintf(" %s ", col.Title)
+
+	borderColor := lipgloss.Color("238")
+	if focused {
+		borderColor = lipgloss.Color("63")
+	}
+
+	style := lipgloss.NewStyle().
+		BorderStyle(lipgloss.RoundedBorder()).
+		BorderForeground(borderColor).
+		Width(width - 2). // -2 for border characters
+		Padding(0, 1)
+
+	titleRendered := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(borderColor).
+		Render(title)
+
+	return titleRendered + "\n" + style.Render(content)
+}
+
+// renderCard renders a single session card.
+func (m *Model) renderCard(session data.Session, width int, selected bool) string {
+	icon := m.statusIcon(session.Status)
+	if m.animStatusIcon != nil {
+		icon = m.animStatusIcon(session.Status, m.animFrame)
+	}
+
+	// First line: icon + title (truncated)
+	titleMaxLen := width - 4 // icon + space + padding
+	if titleMaxLen < 5 {
+		titleMaxLen = 5
+	}
+	title := session.Title
+	if len(title) > titleMaxLen {
+		title = title[:titleMaxLen-1] + "…"
+	}
+	line1 := fmt.Sprintf("%s %s", icon, title)
+
+	// Second line: repo + age
+	repo := session.Repository
+	if repo == "" {
+		repo = "local"
+	}
+	// Shorten repo: "owner/repo" → "repo"
+	if parts := strings.SplitN(repo, "/", 2); len(parts) == 2 {
+		repo = parts[1]
+	}
+	age := formatAge(session.CreatedAt)
+	line2 := fmt.Sprintf("  %s • %s", repo, age)
+	if len(line2) > width {
+		line2 = line2[:width]
+	}
+
+	cardText := line1 + "\n" + line2
+
+	if selected {
+		return m.cardSelectedStyle.Width(width).Render(cardText)
+	}
+	return m.cardStyle.Width(width).Render(cardText)
+}
+
+// formatAge formats a time as a human-readable duration (e.g., "12m", "1h", "2d").
+func formatAge(t time.Time) string {
+	if t.IsZero() {
+		return "—"
+	}
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "<1m"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}
+
+// currentColumn returns a pointer to the column at colCursor, or nil.
+func (m *Model) currentColumn() *Column {
+	if len(m.columns) == 0 || m.colCursor < 0 || m.colCursor >= len(m.columns) {
+		return nil
+	}
+	return &m.columns[m.colCursor]
+}
+
+// clampCursors clamps both column and row cursors to valid ranges.
+func (m *Model) clampCursors() {
+	if len(m.columns) == 0 {
+		m.colCursor = 0
+		m.rowCursor = 0
+		return
+	}
+	if m.colCursor >= len(m.columns) {
+		m.colCursor = len(m.columns) - 1
+	}
+	if m.colCursor < 0 {
+		m.colCursor = 0
+	}
+	m.clampRowCursor()
+}
+
+// clampRowCursor clamps the row cursor for the current column.
+func (m *Model) clampRowCursor() {
+	col := m.currentColumn()
+	if col == nil || len(col.Sessions) == 0 {
+		m.rowCursor = 0
+		return
+	}
+	if m.rowCursor >= len(col.Sessions) {
+		m.rowCursor = len(col.Sessions) - 1
+	}
+	if m.rowCursor < 0 {
+		m.rowCursor = 0
+	}
+}

--- a/internal/tui/components/kanban/kanban_test.go
+++ b/internal/tui/components/kanban/kanban_test.go
@@ -1,0 +1,297 @@
+package kanban
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/maxbeizer/gh-agent-viz/internal/data"
+)
+
+func newTestModel() Model {
+	style := lipgloss.NewStyle()
+	icon := func(s string) string {
+		switch s {
+		case "running":
+			return "🟢"
+		case "needs-input":
+			return "🧑"
+		case "completed":
+			return "✅"
+		case "failed":
+			return "❌"
+		default:
+			return "⚪"
+		}
+	}
+	return New(style, style, style, style.Background(lipgloss.Color("237")), icon, nil)
+}
+
+func testSessions() []data.Session {
+	return []data.Session{
+		{ID: "1", Status: "running", Title: "Fix auth bug", Repository: "owner/repo", CreatedAt: time.Now().Add(-12 * time.Minute)},
+		{ID: "2", Status: "needs-input", Title: "Review PR", Repository: "owner/repo", CreatedAt: time.Now().Add(-5 * time.Minute)},
+		{ID: "3", Status: "completed", Title: "Migrate DB", Repository: "owner/repo", CreatedAt: time.Now().Add(-1 * time.Hour)},
+		{ID: "4", Status: "completed", Title: "Add tests", Repository: "owner/repo", CreatedAt: time.Now().Add(-2 * time.Hour)},
+		{ID: "5", Status: "failed", Title: "Deploy fix", Repository: "owner/repo", CreatedAt: time.Now().Add(-30 * time.Minute)},
+		{ID: "6", Status: "queued", Title: "Queued task", Repository: "owner/repo", CreatedAt: time.Now().Add(-1 * time.Minute)},
+		{ID: "7", Status: "active", Title: "Active task", Repository: "owner/repo", CreatedAt: time.Now().Add(-3 * time.Minute)},
+	}
+}
+
+func TestSetSessions_DistributesIntoColumns(t *testing.T) {
+	m := newTestModel()
+	m.SetSessions(testSessions())
+
+	cols := m.Columns()
+	if len(cols) != 4 {
+		t.Fatalf("expected 4 columns, got %d", len(cols))
+	}
+
+	// Running column: running + queued + active = 3
+	if len(cols[0].Sessions) != 3 {
+		t.Errorf("RUNNING column: expected 3 sessions, got %d", len(cols[0].Sessions))
+	}
+	// Needs input: 1
+	if len(cols[1].Sessions) != 1 {
+		t.Errorf("NEEDS INPUT column: expected 1 session, got %d", len(cols[1].Sessions))
+	}
+	// Completed: 2
+	if len(cols[2].Sessions) != 2 {
+		t.Errorf("COMPLETED column: expected 2 sessions, got %d", len(cols[2].Sessions))
+	}
+	// Failed: 1
+	if len(cols[3].Sessions) != 1 {
+		t.Errorf("FAILED column: expected 1 session, got %d", len(cols[3].Sessions))
+	}
+}
+
+func TestMoveColumn_ClampsAtBounds(t *testing.T) {
+	m := newTestModel()
+	m.SetSessions(testSessions())
+
+	// Start at column 0
+	if m.ColCursor() != 0 {
+		t.Fatalf("expected initial column cursor 0, got %d", m.ColCursor())
+	}
+
+	// Move left past beginning
+	m.MoveColumn(-1)
+	if m.ColCursor() != 0 {
+		t.Errorf("expected column cursor clamped at 0, got %d", m.ColCursor())
+	}
+
+	// Move right
+	m.MoveColumn(1)
+	if m.ColCursor() != 1 {
+		t.Errorf("expected column cursor 1, got %d", m.ColCursor())
+	}
+
+	// Move to last
+	m.MoveColumn(10)
+	if m.ColCursor() != 3 {
+		t.Errorf("expected column cursor clamped at 3, got %d", m.ColCursor())
+	}
+}
+
+func TestMoveRow_ClampsAtBounds(t *testing.T) {
+	m := newTestModel()
+	m.SetSessions(testSessions())
+
+	// Column 0 (RUNNING) has 3 sessions
+	m.MoveRow(1)
+	if m.RowCursor() != 1 {
+		t.Errorf("expected row cursor 1, got %d", m.RowCursor())
+	}
+
+	m.MoveRow(1)
+	if m.RowCursor() != 2 {
+		t.Errorf("expected row cursor 2, got %d", m.RowCursor())
+	}
+
+	// Clamp at end
+	m.MoveRow(1)
+	if m.RowCursor() != 2 {
+		t.Errorf("expected row cursor clamped at 2, got %d", m.RowCursor())
+	}
+
+	// Move up past beginning
+	m.MoveRow(-10)
+	if m.RowCursor() != 0 {
+		t.Errorf("expected row cursor clamped at 0, got %d", m.RowCursor())
+	}
+}
+
+func TestMoveRow_EmptyColumn(t *testing.T) {
+	m := newTestModel()
+	// Only put sessions in RUNNING column
+	m.SetSessions([]data.Session{
+		{ID: "1", Status: "running", Title: "Test"},
+	})
+
+	// Move to NEEDS INPUT column (empty)
+	m.MoveColumn(1)
+	m.MoveRow(1)
+	if m.RowCursor() != 0 {
+		t.Errorf("expected row cursor 0 in empty column, got %d", m.RowCursor())
+	}
+}
+
+func TestSelectedSession_ReturnsCorrectSession(t *testing.T) {
+	m := newTestModel()
+	m.SetSessions(testSessions())
+
+	s := m.SelectedSession()
+	if s == nil {
+		t.Fatal("expected non-nil selected session")
+	}
+	if s.ID != "1" {
+		t.Errorf("expected session ID '1', got %q", s.ID)
+	}
+
+	// Move to second row
+	m.MoveRow(1)
+	s = m.SelectedSession()
+	if s == nil || s.Status != "queued" {
+		t.Errorf("expected queued session at row 1")
+	}
+
+	// Move to NEEDS INPUT column
+	m.MoveColumn(1)
+	s = m.SelectedSession()
+	if s == nil || s.ID != "2" {
+		t.Errorf("expected session ID '2' in NEEDS INPUT column, got %v", s)
+	}
+}
+
+func TestSelectedSession_EmptyColumn(t *testing.T) {
+	m := newTestModel()
+	m.SetSessions([]data.Session{})
+
+	s := m.SelectedSession()
+	if s != nil {
+		t.Error("expected nil selected session for empty board")
+	}
+}
+
+func TestColumnWidth_Calculation(t *testing.T) {
+	m := newTestModel()
+	m.SetSize(100, 24)
+	m.SetSessions(testSessions())
+
+	w := m.ColumnWidth()
+	// 4 columns, 3 gaps of 1 space each = 97 available, 97/4 = 24
+	expected := (100 - 3) / 4
+	if w != expected {
+		t.Errorf("expected column width %d, got %d", expected, w)
+	}
+}
+
+func TestColumnWidth_MinWidth(t *testing.T) {
+	m := newTestModel()
+	m.SetSize(40, 24) // 40 - 3 = 37, 37/4 = 9 which is < 20
+	m.SetSessions(testSessions())
+
+	w := m.ColumnWidth()
+	if w < 20 {
+		t.Errorf("expected column width >= 20, got %d", w)
+	}
+}
+
+func TestView_RendersAllColumns(t *testing.T) {
+	m := newTestModel()
+	m.SetSize(120, 24)
+	m.SetSessions(testSessions())
+
+	view := m.View()
+	if !strings.Contains(view, "RUNNING") {
+		t.Error("expected RUNNING column in view")
+	}
+	if !strings.Contains(view, "NEEDS INPUT") {
+		t.Error("expected NEEDS INPUT column in view")
+	}
+	if !strings.Contains(view, "COMPLETED") {
+		t.Error("expected COMPLETED column in view")
+	}
+	if !strings.Contains(view, "FAILED") {
+		t.Error("expected FAILED column in view")
+	}
+}
+
+func TestView_EmptyColumnsShowPlaceholder(t *testing.T) {
+	m := newTestModel()
+	m.SetSize(120, 24)
+	// Only running sessions
+	m.SetSessions([]data.Session{
+		{ID: "1", Status: "running", Title: "Only runner"},
+	})
+
+	view := m.View()
+	if !strings.Contains(view, "(no sessions)") {
+		t.Error("expected placeholder text for empty columns")
+	}
+}
+
+func TestSetAnimFrame(t *testing.T) {
+	m := newTestModel()
+	m.SetAnimFrame(42)
+	if m.animFrame != 42 {
+		t.Errorf("expected animFrame 42, got %d", m.animFrame)
+	}
+}
+
+func TestMoveColumn_ResetsRowCursor(t *testing.T) {
+	m := newTestModel()
+	m.SetSessions(testSessions())
+
+	// Move to row 2 in RUNNING column (3 items)
+	m.MoveRow(2)
+	if m.RowCursor() != 2 {
+		t.Fatalf("expected row 2, got %d", m.RowCursor())
+	}
+
+	// Move to NEEDS INPUT column (1 item) — row should clamp to 0
+	m.MoveColumn(1)
+	if m.RowCursor() != 0 {
+		t.Errorf("expected row cursor clamped to 0 when moving to smaller column, got %d", m.RowCursor())
+	}
+}
+
+func TestView_CardShowsSessionTitle(t *testing.T) {
+	m := newTestModel()
+	m.SetSize(120, 24)
+	m.SetSessions([]data.Session{
+		{ID: "1", Status: "running", Title: "Fix auth bug", Repository: "owner/repo"},
+	})
+
+	view := m.View()
+	if !strings.Contains(view, "Fix auth bug") {
+		t.Error("expected session title in view")
+	}
+}
+
+func TestFormatAge(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Second, "<1m"},
+		{12 * time.Minute, "12m"},
+		{90 * time.Minute, "1h"},
+		{25 * time.Hour, "1d"},
+	}
+	for _, tt := range tests {
+		got := formatAge(time.Now().Add(-tt.d))
+		if got != tt.want {
+			t.Errorf("formatAge(%v ago) = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}
+
+func TestFormatAge_ZeroTime(t *testing.T) {
+	got := formatAge(time.Time{})
+	if got != "—" {
+		t.Errorf("formatAge(zero) = %q, want '—'", got)
+	}
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -20,6 +20,7 @@ type Keybindings struct {
 	GroupBy        key.Binding
 	ExpandGroup    key.Binding
 	ToggleFollow   key.Binding
+	ToggleKanban   key.Binding
 }
 
 // NewKeybindings creates the default key bindings for the TUI
@@ -88,6 +89,10 @@ func NewKeybindings() Keybindings {
 		ToggleFollow: key.NewBinding(
 			key.WithKeys("f"),
 			key.WithHelp("f", "follow"),
+		),
+		ToggleKanban: key.NewBinding(
+			key.WithKeys("K"),
+			key.WithHelp("K", "kanban"),
 		),
 	}
 }


### PR DESCRIPTION
Adds an alternate kanban board view (toggle with `K` key) showing sessions organized into status columns.

- Columns: Running, Needs Input, Completed, Failed
- Navigate: `h/l` between columns, `j/k` within
- `enter` for details, `esc` back to list
- Responsive column sizing
- Animated status icons in cards

Closes #61