### PR TITLE
feat: show explicit attention reasons in badges and detail view

### DIFF
--- a/internal/tui/components/tasklist/tasklist.go
+++ b/internal/tui/components/tasklist/tasklist.go
@@ -449,14 +449,15 @@ func sessionBadge(session data.Session, duplicateCount int) string {
 		return badge
 	}
 	if data.SessionNeedsAttention(session) {
-		badge := fmt.Sprintf("💤 %s", formatIdleDuration(time.Since(session.UpdatedAt)))
+		idle := time.Since(session.UpdatedAt)
+		badge := fmt.Sprintf("⚠️ idle %s — may be stuck", formatIdleDuration(idle))
 		if duplicateCount > 0 {
 			badge += fmt.Sprintf(" (+%d older)", duplicateCount)
 		}
 		return badge
 	}
 	if isActiveStatus(session.Status) && !session.UpdatedAt.IsZero() && time.Since(session.UpdatedAt) >= data.AttentionStaleMax {
-		return "😴 stale"
+		return "😴 stale — no activity 4h+"
 	}
 	if !isActiveStatus(session.Status) || session.UpdatedAt.IsZero() {
 		return ""

--- a/internal/tui/components/tasklist/tasklist_test.go
+++ b/internal/tui/components/tasklist/tasklist_test.go
@@ -275,7 +275,7 @@ func TestView_CardShowsAttentionBadges(t *testing.T) {
 	if !strings.Contains(view, "🧑 waiting on you") {
 		t.Fatalf("expected needs-input badge, got: %s", view)
 	}
-	if !strings.Contains(view, "💤 ~30m") {
+	if !strings.Contains(view, "⚠️ idle ~30m — may be stuck") {
 		t.Fatalf("expected idle badge, got: %s", view)
 	}
 }
@@ -446,11 +446,11 @@ func TestSessionBadge_IdleShowsDuration(t *testing.T) {
 		UpdatedAt: time.Now().Add(-30 * time.Minute),
 	}
 	badge := sessionBadge(session, 0)
-	if !strings.HasPrefix(badge, "💤 ~") {
+	if !strings.HasPrefix(badge, "⚠️ idle ~") {
 		t.Fatalf("expected idle badge with duration, got %q", badge)
 	}
-	if strings.Contains(badge, "check progress") {
-		t.Fatalf("old 'check progress' text should be gone, got %q", badge)
+	if !strings.Contains(badge, "— may be stuck") {
+		t.Fatalf("expected 'may be stuck' suffix, got %q", badge)
 	}
 }
 
@@ -460,8 +460,22 @@ func TestSessionBadge_StaleShowsEmoji(t *testing.T) {
 		UpdatedAt: time.Now().Add(-5 * time.Hour),
 	}
 	badge := sessionBadge(session, 0)
-	if badge != "😴 stale" {
+	if badge != "😴 stale — no activity 4h+" {
 		t.Fatalf("expected stale badge for session idle >4h, got %q", badge)
+	}
+}
+
+func TestSessionBadge_IdleWithDuplicates(t *testing.T) {
+	session := data.Session{
+		Status:    "running",
+		UpdatedAt: time.Now().Add(-25 * time.Minute),
+	}
+	badge := sessionBadge(session, 3)
+	if !strings.Contains(badge, "⚠️ idle") {
+		t.Fatalf("expected idle badge, got %q", badge)
+	}
+	if !strings.Contains(badge, "(+3 older)") {
+		t.Fatalf("expected duplicate count, got %q", badge)
 	}
 }
 


### PR DESCRIPTION
Makes attention reasons explicit and descriptive:

- Idle badge: `⚠️ idle 23m — may be stuck` (was `💤 ~23m`)
- Stale badge: `😴 stale — no activity 4h+` (was `😴 stale`)
- Detail view: New attention reason section explaining why session needs attention
- needs-input and failed badges unchanged (already clear)

Closes #108