### PR TITLE
feat: visual polish — colored gutters, dividers, and depth

### DIFF
--- a/internal/tui/components/header/header.go
+++ b/internal/tui/components/header/header.go
@@ -104,10 +104,14 @@ func (m Model) View() string {
 	tabBar := strings.Join(renderedTabs, "")
 	tabLine := lipgloss.JoinHorizontal(lipgloss.Center, title, "  ", tabBar)
 
+	separator := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("238")).
+		Render(strings.Repeat("─", m.width))
+
 	if m.showBanner() {
 		styledBanner := m.titleStyle.Render(Banner)
-		return styledBanner + "\n" + tabLine + "\n"
+		return styledBanner + "\n" + tabLine + "\n" + separator + "\n"
 	}
 
-	return tabLine + "\n"
+	return tabLine + "\n" + separator + "\n"
 }

--- a/internal/tui/components/taskdetail/taskdetail.go
+++ b/internal/tui/components/taskdetail/taskdetail.go
@@ -59,13 +59,15 @@ func (m Model) View() string {
 	)
 
 	if tl := RenderTimeline(m.session, timelineWidth(m.width)); tl != "" {
-		details = append(details, "", fmt.Sprintf("Timeline:   %s", tl))
+		details = append(details, sectionDivider(m.width-4))
+		details = append(details, fmt.Sprintf("Timeline:   %s", tl))
 	}
 
 	// Show telemetry if available
 	if m.session.Telemetry != nil {
 		t := m.session.Telemetry
-		details = append(details, "", m.titleStyle.Render("Session Stats"))
+		details = append(details, sectionDivider(m.width-4))
+		details = append(details, m.titleStyle.Render("Session Stats"))
 		if t.Duration > 0 {
 			details = append(details, fmt.Sprintf("⏱ Duration: %s", formatDuration(t.Duration)))
 		}
@@ -83,7 +85,8 @@ func (m Model) View() string {
 	// Show dependency graph if relationships exist
 	graph := ParseSessionDeps(m.session, m.allSessions)
 	if rendered := RenderDepGraph(graph, m.width); rendered != "" {
-		details = append(details, "", m.titleStyle.Render("Related Sessions"), rendered)
+		details = append(details, sectionDivider(m.width-4))
+		details = append(details, m.titleStyle.Render("Related Sessions"), rendered)
 	}
 
 	return m.borderStyle.Render(joinVertical(details))
@@ -153,12 +156,14 @@ func (m Model) ViewSplit() string {
 	)
 
 	if tl := RenderTimeline(m.session, timelineWidth(m.width)); tl != "" {
-		details = append(details, "", fmt.Sprintf("Timeline:   %s", tl))
+		details = append(details, sectionDivider(m.width-4))
+		details = append(details, fmt.Sprintf("Timeline:   %s", tl))
 	}
 
 	if m.session.Telemetry != nil {
 		t := m.session.Telemetry
-		details = append(details, "", m.titleStyle.Render("Session Stats"))
+		details = append(details, sectionDivider(m.width-4))
+		details = append(details, m.titleStyle.Render("Session Stats"))
 		if t.Duration > 0 {
 			details = append(details, fmt.Sprintf("⏱ Duration: %s", formatDuration(t.Duration)))
 		}
@@ -176,7 +181,8 @@ func (m Model) ViewSplit() string {
 	// Show dependency graph if relationships exist
 	graph := ParseSessionDeps(m.session, m.allSessions)
 	if rendered := RenderDepGraph(graph, m.width); rendered != "" {
-		details = append(details, "", m.titleStyle.Render("Related Sessions"), rendered)
+		details = append(details, sectionDivider(m.width-4))
+		details = append(details, m.titleStyle.Render("Related Sessions"), rendered)
 	}
 
 	style := lipgloss.NewStyle().
@@ -222,6 +228,14 @@ func detailTimestamp(ts time.Time) string {
 
 func detailTitle(title string) string {
 	return detailValue(title, "Untitled Session")
+}
+
+// sectionDivider renders a horizontal rule for visual separation between sections.
+func sectionDivider(width int) string {
+	if width <= 0 {
+		width = 40
+	}
+	return lipgloss.NewStyle().Foreground(lipgloss.Color("238")).Render(strings.Repeat("─", width))
 }
 
 func formatDuration(d time.Duration) string {

--- a/internal/tui/components/tasklist/tasklist_test.go
+++ b/internal/tui/components/tasklist/tasklist_test.go
@@ -104,7 +104,7 @@ func TestViewEmptyAndLoadingStates(t *testing.T) {
 
 	// After data arrives, loading is false — show empty state
 	model.loading = false
-	if got := model.View(); !strings.Contains(got, "All quiet on the agent front") {
+	if got := model.View(); !strings.Contains(got, "All quiet out here") {
 		t.Fatalf("expected empty state, got: %s", got)
 	}
 }
@@ -225,7 +225,7 @@ func TestView_ImprovedEmptyState(t *testing.T) {
 	model.loading = false
 
 	view := model.View()
-	if !strings.Contains(view, "All quiet on the agent front") {
+	if !strings.Contains(view, "All quiet out here") {
 		t.Error("expected whimsical empty state message")
 	}
 	if !strings.Contains(view, "refresh") {

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -70,8 +70,9 @@ func newDefaultTheme() *Theme {
 			Padding(0, 1),
 		TableRowSelected: lipgloss.NewStyle().
 			Padding(0, 1).
-			Background(lipgloss.Color("237")).
-			Foreground(lipgloss.Color("15")),
+			Background(lipgloss.Color("236")).
+			Foreground(lipgloss.Color("15")).
+			Bold(true),
 		Border: lipgloss.NewStyle().
 			BorderStyle(lipgloss.RoundedBorder()).
 			BorderForeground(lipgloss.Color("238")),
@@ -125,8 +126,9 @@ func newAdaptiveDefaultTheme() *Theme {
 			Padding(0, 1),
 		TableRowSelected: lipgloss.NewStyle().
 			Padding(0, 1).
-			Background(lipgloss.AdaptiveColor{Light: "254", Dark: "237"}).
-			Foreground(lipgloss.AdaptiveColor{Light: "0", Dark: "15"}),
+			Background(lipgloss.AdaptiveColor{Light: "254", Dark: "236"}).
+			Foreground(lipgloss.AdaptiveColor{Light: "0", Dark: "15"}).
+			Bold(true),
 		Border: lipgloss.NewStyle().
 			BorderStyle(lipgloss.RoundedBorder()).
 			BorderForeground(lipgloss.AdaptiveColor{Light: "249", Dark: "238"}),
@@ -181,7 +183,8 @@ func newCatppuccinMochaTheme() *Theme {
 		TableRowSelected: lipgloss.NewStyle().
 			Padding(0, 1).
 			Background(lipgloss.Color("#313244")).
-			Foreground(lipgloss.Color("#cdd6f4")),
+			Foreground(lipgloss.Color("#cdd6f4")).
+			Bold(true),
 		Border: lipgloss.NewStyle().
 			BorderStyle(lipgloss.RoundedBorder()).
 			BorderForeground(lipgloss.Color("#313244")),
@@ -236,7 +239,8 @@ func newDraculaTheme() *Theme {
 		TableRowSelected: lipgloss.NewStyle().
 			Padding(0, 1).
 			Background(lipgloss.Color("#44475a")).
-			Foreground(lipgloss.Color("#f8f8f2")),
+			Foreground(lipgloss.Color("#f8f8f2")).
+			Bold(true),
 		Border: lipgloss.NewStyle().
 			BorderStyle(lipgloss.RoundedBorder()).
 			BorderForeground(lipgloss.Color("#44475a")),
@@ -291,7 +295,8 @@ func newTokyoNightTheme() *Theme {
 		TableRowSelected: lipgloss.NewStyle().
 			Padding(0, 1).
 			Background(lipgloss.Color("#33467c")).
-			Foreground(lipgloss.Color("#c0caf5")),
+			Foreground(lipgloss.Color("#c0caf5")).
+			Bold(true),
 		Border: lipgloss.NewStyle().
 			BorderStyle(lipgloss.RoundedBorder()).
 			BorderForeground(lipgloss.Color("#33467c")),


### PR DESCRIPTION
Adds visual depth and polish inspired by lazygit, btop++, and k9s:

- Status-colored gutter bars (green=running, red=failed, etc.)
- Section dividers (─────) in detail view between metadata/timeline/stats
- Richer selected-row styling with bold text
- Improved empty state with box-drawing art
- Header bottom border separator

Closes #110