### PR TITLE
feat: add ? help overlay and simplify footer hints

### DIFF
--- a/internal/tui/components/help/help.go
+++ b/internal/tui/components/help/help.go
@@ -1,0 +1,110 @@
+package help
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Model represents the help overlay state.
+type Model struct {
+	visible bool
+	width   int
+	height  int
+}
+
+// New creates a new help overlay model.
+func New() Model {
+	return Model{}
+}
+
+// Toggle flips help overlay visibility.
+func (m *Model) Toggle() {
+	m.visible = !m.visible
+}
+
+// Visible returns whether the help overlay is shown.
+func (m Model) Visible() bool {
+	return m.visible
+}
+
+// SetSize updates the available dimensions for the overlay.
+func (m *Model) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+}
+
+// View renders the help overlay panel. Returns empty string when hidden.
+func (m Model) View() string {
+	if !m.visible {
+		return ""
+	}
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.AdaptiveColor{Light: "55", Dark: "99"})
+	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "28", Dark: "42"}).Bold(true)
+	descStyle := lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "240", Dark: "252"})
+	sectionStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.AdaptiveColor{Light: "27", Dark: "63"}).MarginBottom(1)
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "244", Dark: "241"}).Italic(true)
+
+	formatKey := func(k, desc string) string {
+		return keyStyle.Render(k) + "  " + descStyle.Render(desc)
+	}
+
+	// Navigation section
+	nav := sectionStyle.Render("Navigation") + "\n" +
+		formatKey("↑/↓ j/k", "navigate") + "\n" +
+		formatKey("enter", "details") + "\n" +
+		formatKey("esc", "back") + "\n" +
+		formatKey("tab", "cycle filter") + "\n" +
+		formatKey("a", "attention tab")
+
+	// Actions section
+	actions := sectionStyle.Render("Actions") + "\n" +
+		formatKey("o", "open PR") + "\n" +
+		formatKey("s", "resume session") + "\n" +
+		formatKey("x", "dismiss") + "\n" +
+		formatKey("r", "refresh") + "\n" +
+		formatKey("p", "toggle preview")
+
+	// Views section
+	views := sectionStyle.Render("Views") + "\n" +
+		formatKey("K", "kanban board") + "\n" +
+		formatKey("l", "logs") + "\n" +
+		formatKey("p", "preview pane")
+
+	// Groups section
+	groups := sectionStyle.Render("Groups") + "\n" +
+		formatKey("g", "cycle grouping") + "\n" +
+		formatKey("⎵", "expand/collapse")
+
+	// Log View section
+	logView := sectionStyle.Render("Log View") + "\n" +
+		formatKey("d/u", "page down/up") + "\n" +
+		formatKey("g/G", "top/bottom") + "\n" +
+		formatKey("f", "toggle follow")
+
+	// Layout: two columns for Navigation+Actions, Views+Groups
+	colWidth := 28
+	col := func(content string) string {
+		return lipgloss.NewStyle().Width(colWidth).Render(content)
+	}
+
+	topRow := lipgloss.JoinHorizontal(lipgloss.Top, col(nav), col(actions))
+	midRow := lipgloss.JoinHorizontal(lipgloss.Top, col(views), col(groups))
+
+	body := strings.Join([]string{topRow, midRow, logView}, "\n\n")
+
+	closeHint := dimStyle.Render("Press ? or esc to close")
+	body += "\n\n" + lipgloss.NewStyle().Width(colWidth*2).Align(lipgloss.Center).Render(closeHint)
+
+	boxStyle := lipgloss.NewStyle().
+		BorderStyle(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.AdaptiveColor{Light: "249", Dark: "238"}).
+		Padding(1, 3).
+		Width(colWidth*2 + 8)
+
+	title := titleStyle.Render(" Keyboard Shortcuts ")
+	box := boxStyle.BorderTop(true).Render(title + "\n\n" + body)
+
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
+}

--- a/internal/tui/components/help/help_test.go
+++ b/internal/tui/components/help/help_test.go
@@ -1,0 +1,40 @@
+package help
+
+import "testing"
+
+func TestToggle(t *testing.T) {
+	m := New()
+	if m.Visible() {
+		t.Fatal("expected help to start hidden")
+	}
+	m.Toggle()
+	if !m.Visible() {
+		t.Fatal("expected help to be visible after toggle")
+	}
+	m.Toggle()
+	if m.Visible() {
+		t.Fatal("expected help to be hidden after second toggle")
+	}
+}
+
+func TestView_VisibleReturnsContent(t *testing.T) {
+	m := New()
+	m.SetSize(120, 40)
+	m.Toggle()
+	v := m.View()
+	if v == "" {
+		t.Fatal("expected non-empty view when visible")
+	}
+	if len(v) < 50 {
+		t.Fatal("expected substantial content in help view")
+	}
+}
+
+func TestView_HiddenReturnsEmpty(t *testing.T) {
+	m := New()
+	m.SetSize(120, 40)
+	v := m.View()
+	if v != "" {
+		t.Fatalf("expected empty view when hidden, got %q", v)
+	}
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -21,6 +21,7 @@ type Keybindings struct {
 	ExpandGroup    key.Binding
 	ToggleFollow   key.Binding
 	ToggleKanban   key.Binding
+	ShowHelp       key.Binding
 }
 
 // NewKeybindings creates the default key bindings for the TUI
@@ -93,6 +94,10 @@ func NewKeybindings() Keybindings {
 		ToggleKanban: key.NewBinding(
 			key.WithKeys("K"),
 			key.WithHelp("K", "kanban"),
+		),
+		ShowHelp: key.NewBinding(
+			key.WithKeys("?"),
+			key.WithHelp("?", "help"),
 		),
 	}
 }

--- a/internal/tui/ui_test.go
+++ b/internal/tui/ui_test.go
@@ -214,8 +214,12 @@ func TestUpdateFooterHints_DetailViewShowsResumeForResumableSession(t *testing.T
 
 	m.updateFooterHints()
 	footerView := m.footer.View()
-	if !strings.Contains(footerView, "resume") {
-		t.Fatalf("expected resume hint in detail view for resumable session, got: %s", footerView)
+	// Simplified footer now shows logs instead of resume; advanced hints moved to ? overlay
+	if !strings.Contains(footerView, "logs") {
+		t.Fatalf("expected logs hint in detail view footer, got: %s", footerView)
+	}
+	if !strings.Contains(footerView, "? help") {
+		t.Fatalf("expected help hint in detail view footer, got: %s", footerView)
 	}
 }
 
@@ -318,14 +322,12 @@ func TestUpdateFooterHints_LocalSessionShowsOnlyAvailableActions(t *testing.T) {
 
 	m.updateFooterHints()
 	footerView := m.footer.View()
-	if !strings.Contains(footerView, "resume") {
-		t.Fatalf("expected resume hint for resumable local session, got: %s", footerView)
+	// Simplified footer shows fixed hints; context-dependent hints moved to ? overlay
+	if !strings.Contains(footerView, "? help") {
+		t.Fatalf("expected help hint in list view footer, got: %s", footerView)
 	}
-	if strings.Contains(footerView, "logs") {
-		t.Fatalf("expected logs hint to be hidden for local session, got: %s", footerView)
-	}
-	if strings.Contains(footerView, "open PR") {
-		t.Fatalf("expected open PR hint to be hidden for local session, got: %s", footerView)
+	if !strings.Contains(footerView, "navigate") {
+		t.Fatalf("expected navigate hint in list view footer, got: %s", footerView)
 	}
 }
 
@@ -344,11 +346,12 @@ func TestUpdateFooterHints_AgentSessionWithoutPRHidesOpenPRHint(t *testing.T) {
 
 	m.updateFooterHints()
 	footerView := m.footer.View()
-	if !strings.Contains(footerView, "logs") {
-		t.Fatalf("expected logs hint for agent session, got: %s", footerView)
-	}
+	// Simplified footer no longer shows context-dependent hints like open PR
 	if strings.Contains(footerView, "open PR") {
-		t.Fatalf("expected open PR hint to be hidden when PR is not linked, got: %s", footerView)
+		t.Fatalf("expected open PR hint to be hidden in simplified footer, got: %s", footerView)
+	}
+	if !strings.Contains(footerView, "? help") {
+		t.Fatalf("expected help hint in list view footer, got: %s", footerView)
 	}
 }
 


### PR DESCRIPTION
Simplifies the footer bar to show only essential shortcuts (≤6 per mode) and adds a `?` key that toggles a centered help overlay with all keybindings organized by category.

- Footer reduced from 10-12 hints to 5-6 essentials
- Help overlay shows full keybinding reference
- Works in all view modes (list, detail, log, kanban)
- `?` or `esc` dismisses the overlay

Closes #107