### PR TITLE
fix: make attention badges actionable instead of speculative

### DIFF
--- a/internal/tui/components/taskdetail/taskdetail.go
+++ b/internal/tui/components/taskdetail/taskdetail.go
@@ -235,10 +235,10 @@ func attentionReason(session *data.Session) string {
 	}
 	idle := time.Since(session.UpdatedAt)
 	if idle >= data.AttentionStaleMax {
-		return fmt.Sprintf("😴 No activity for %s — session may be abandoned.", formatDuration(idle))
+		return fmt.Sprintf("😴 No activity for %s. Press 's' to resume or 'x' to dismiss.", formatDuration(idle))
 	}
 	if idle >= data.AttentionStaleThreshold {
-		return fmt.Sprintf("⚠️ Session has been idle for %s while status is \"%s\". This may indicate the agent is stuck.", formatDuration(idle), session.Status)
+		return fmt.Sprintf("⚠️ Idle for %s while %s. Press 'l' to check logs or 's' to resume.", formatDuration(idle), session.Status)
 	}
 	return ""
 }

--- a/internal/tui/components/taskdetail/taskdetail_test.go
+++ b/internal/tui/components/taskdetail/taskdetail_test.go
@@ -158,11 +158,11 @@ func TestAttentionReason_Idle(t *testing.T) {
 		UpdatedAt: time.Now().Add(-30 * time.Minute),
 	}
 	got := attentionReason(s)
-	if !strings.Contains(got, "⚠️") || !strings.Contains(got, "idle") {
+	if !strings.Contains(got, "⚠️") || !strings.Contains(strings.ToLower(got), "idle") {
 		t.Fatalf("expected idle attention reason, got %q", got)
 	}
-	if !strings.Contains(got, "stuck") {
-		t.Fatalf("expected stuck hint, got %q", got)
+	if !strings.Contains(got, "check logs") || !strings.Contains(got, "resume") {
+		t.Fatalf("expected actionable idle reason, got %q", got)
 	}
 }
 
@@ -172,7 +172,7 @@ func TestAttentionReason_Stale(t *testing.T) {
 		UpdatedAt: time.Now().Add(-5 * time.Hour),
 	}
 	got := attentionReason(s)
-	if !strings.Contains(got, "😴") || !strings.Contains(got, "abandoned") {
+	if !strings.Contains(got, "😴") || !strings.Contains(got, "dismiss") {
 		t.Fatalf("expected stale attention reason, got %q", got)
 	}
 }

--- a/internal/tui/components/tasklist/tasklist.go
+++ b/internal/tui/components/tasklist/tasklist.go
@@ -458,14 +458,14 @@ func sessionBadge(session data.Session, duplicateCount int) string {
 	}
 	if data.SessionNeedsAttention(session) {
 		idle := time.Since(session.UpdatedAt)
-		badge := fmt.Sprintf("⚠️ idle %s — may be stuck", formatIdleDuration(idle))
+		badge := fmt.Sprintf("⚠️ idle %s — check logs", formatIdleDuration(idle))
 		if duplicateCount > 0 {
 			badge += fmt.Sprintf(" (+%d older)", duplicateCount)
 		}
 		return badge
 	}
 	if isActiveStatus(session.Status) && !session.UpdatedAt.IsZero() && time.Since(session.UpdatedAt) >= data.AttentionStaleMax {
-		return "😴 stale — no activity 4h+"
+		return "😴 stale — consider dismissing"
 	}
 	if !isActiveStatus(session.Status) || session.UpdatedAt.IsZero() {
 		return ""

--- a/internal/tui/components/tasklist/tasklist_test.go
+++ b/internal/tui/components/tasklist/tasklist_test.go
@@ -275,7 +275,7 @@ func TestView_CardShowsAttentionBadges(t *testing.T) {
 	if !strings.Contains(view, "🧑 waiting on you") {
 		t.Fatalf("expected needs-input badge, got: %s", view)
 	}
-	if !strings.Contains(view, "⚠️ idle ~30m — may be stuck") {
+	if !strings.Contains(view, "⚠️ idle ~30m — check logs") {
 		t.Fatalf("expected idle badge, got: %s", view)
 	}
 }
@@ -449,8 +449,8 @@ func TestSessionBadge_IdleShowsDuration(t *testing.T) {
 	if !strings.HasPrefix(badge, "⚠️ idle ~") {
 		t.Fatalf("expected idle badge with duration, got %q", badge)
 	}
-	if !strings.Contains(badge, "— may be stuck") {
-		t.Fatalf("expected 'may be stuck' suffix, got %q", badge)
+	if !strings.Contains(badge, "— check logs") {
+		t.Fatalf("expected 'check logs' suffix, got %q", badge)
 	}
 }
 
@@ -460,7 +460,7 @@ func TestSessionBadge_StaleShowsEmoji(t *testing.T) {
 		UpdatedAt: time.Now().Add(-5 * time.Hour),
 	}
 	badge := sessionBadge(session, 0)
-	if badge != "😴 stale — no activity 4h+" {
+	if badge != "😴 stale — consider dismissing" {
 		t.Fatalf("expected stale badge for session idle >4h, got %q", badge)
 	}
 }


### PR DESCRIPTION
Badges now tell users what to **do**, not speculate about what's wrong:

| Context | Before | After |
|---------|--------|-------|
| List badge (idle) | `⚠️ idle ~23m — may be stuck` | `⚠️ idle ~23m — check logs` |
| List badge (stale) | `😴 stale — no activity 4h+` | `😴 stale — consider dismissing` |
| Detail (idle) | `may indicate the agent is stuck` | `Press 'l' to check logs or 's' to resume` |
| Detail (stale) | `session may be abandoned` | `Press 's' to resume or 'x' to dismiss` |