### PR TITLE
feat: rework attention model — only needs-input and failed

### DIFF
--- a/internal/data/session.go
+++ b/internal/data/session.go
@@ -75,19 +75,12 @@ func (s Session) ToAgentTask() AgentTask {
 	}
 }
 
-// SessionNeedsAttention indicates whether a session likely requires operator action.
+// SessionNeedsAttention indicates whether a session requires operator action.
+// Only true for sessions explicitly waiting on user input or that have failed.
+// Idle sessions are informational, not actionable.
 func SessionNeedsAttention(session Session) bool {
 	status := strings.ToLower(strings.TrimSpace(session.Status))
-	if status == "needs-input" || status == "failed" {
-		return true
-	}
-
-	if !StatusIsActive(session.Status) || session.UpdatedAt.IsZero() {
-		return false
-	}
-
-	idle := time.Since(session.UpdatedAt)
-	return idle >= AttentionStaleThreshold && idle < AttentionStaleMax
+	return status == "needs-input" || status == "failed"
 }
 
 // StatusIsActive determines if a status string represents an active session.

--- a/internal/data/session_test.go
+++ b/internal/data/session_test.go
@@ -22,9 +22,9 @@ func TestSessionNeedsAttention(t *testing.T) {
 			want:    true,
 		},
 		{
-			name:    "active stale session",
+			name:    "active idle session is not attention",
 			session: Session{Status: "running", UpdatedAt: time.Now().Add(-AttentionStaleThreshold - time.Minute)},
-			want:    true,
+			want:    false,
 		},
 		{
 			name:    "active fresh session",
@@ -32,12 +32,12 @@ func TestSessionNeedsAttention(t *testing.T) {
 			want:    false,
 		},
 		{
-			name:    "active session idle 2h needs attention",
+			name:    "active session idle 2h not attention",
 			session: Session{Status: "running", UpdatedAt: time.Now().Add(-2 * time.Hour)},
-			want:    true,
+			want:    false,
 		},
 		{
-			name:    "active session idle 5h past max",
+			name:    "active session idle 5h not attention",
 			session: Session{Status: "running", UpdatedAt: time.Now().Add(-5 * time.Hour)},
 			want:    false,
 		},

--- a/internal/tui/components/taskdetail/taskdetail.go
+++ b/internal/tui/components/taskdetail/taskdetail.go
@@ -228,17 +228,7 @@ func attentionReason(session *data.Session) string {
 		return "🧑 This session is waiting for your input to continue."
 	}
 	if status == "failed" {
-		return "🚨 This session has failed. Check logs for details."
-	}
-	if !data.StatusIsActive(session.Status) || session.UpdatedAt.IsZero() {
-		return ""
-	}
-	idle := time.Since(session.UpdatedAt)
-	if idle >= data.AttentionStaleMax {
-		return fmt.Sprintf("😴 No activity for %s. Press 's' to resume or 'x' to dismiss.", formatDuration(idle))
-	}
-	if idle >= data.AttentionStaleThreshold {
-		return fmt.Sprintf("⚠️ Idle for %s while %s. Press 'l' to check logs or 's' to resume.", formatDuration(idle), session.Status)
+		return "🚨 This session has failed. Press 'l' to check logs."
 	}
 	return ""
 }

--- a/internal/tui/components/taskdetail/taskdetail_test.go
+++ b/internal/tui/components/taskdetail/taskdetail_test.go
@@ -152,28 +152,25 @@ func TestAttentionReason_Failed(t *testing.T) {
 	}
 }
 
-func TestAttentionReason_Idle(t *testing.T) {
+func TestAttentionReason_Idle_NoLongerAttention(t *testing.T) {
 	s := &data.Session{
 		Status:    "running",
 		UpdatedAt: time.Now().Add(-30 * time.Minute),
 	}
 	got := attentionReason(s)
-	if !strings.Contains(got, "⚠️") || !strings.Contains(strings.ToLower(got), "idle") {
-		t.Fatalf("expected idle attention reason, got %q", got)
-	}
-	if !strings.Contains(got, "check logs") || !strings.Contains(got, "resume") {
-		t.Fatalf("expected actionable idle reason, got %q", got)
+	if got != "" {
+		t.Fatalf("idle sessions should not have attention reason, got %q", got)
 	}
 }
 
-func TestAttentionReason_Stale(t *testing.T) {
+func TestAttentionReason_Stale_NoLongerAttention(t *testing.T) {
 	s := &data.Session{
 		Status:    "running",
 		UpdatedAt: time.Now().Add(-5 * time.Hour),
 	}
 	got := attentionReason(s)
-	if !strings.Contains(got, "😴") || !strings.Contains(got, "dismiss") {
-		t.Fatalf("expected stale attention reason, got %q", got)
+	if got != "" {
+		t.Fatalf("stale sessions should not have attention reason, got %q", got)
 	}
 }
 

--- a/internal/tui/components/tasklist/tasklist_test.go
+++ b/internal/tui/components/tasklist/tasklist_test.go
@@ -275,7 +275,7 @@ func TestView_CardShowsAttentionBadges(t *testing.T) {
 	if !strings.Contains(view, "🧑 waiting on you") {
 		t.Fatalf("expected needs-input badge, got: %s", view)
 	}
-	if !strings.Contains(view, "⚠️ idle ~30m — check logs") {
+	if !strings.Contains(view, "💤 idle ~30m") {
 		t.Fatalf("expected idle badge, got: %s", view)
 	}
 }
@@ -446,11 +446,8 @@ func TestSessionBadge_IdleShowsDuration(t *testing.T) {
 		UpdatedAt: time.Now().Add(-30 * time.Minute),
 	}
 	badge := sessionBadge(session, 0)
-	if !strings.HasPrefix(badge, "⚠️ idle ~") {
-		t.Fatalf("expected idle badge with duration, got %q", badge)
-	}
-	if !strings.Contains(badge, "— check logs") {
-		t.Fatalf("expected 'check logs' suffix, got %q", badge)
+	if !strings.HasPrefix(badge, "💤 idle ~") {
+		t.Fatalf("expected calm idle badge with duration, got %q", badge)
 	}
 }
 
@@ -460,8 +457,8 @@ func TestSessionBadge_StaleShowsEmoji(t *testing.T) {
 		UpdatedAt: time.Now().Add(-5 * time.Hour),
 	}
 	badge := sessionBadge(session, 0)
-	if badge != "😴 stale — consider dismissing" {
-		t.Fatalf("expected stale badge for session idle >4h, got %q", badge)
+	if !strings.HasPrefix(badge, "💤 idle ~") {
+		t.Fatalf("expected calm idle badge for session idle >4h, got %q", badge)
 	}
 }
 
@@ -471,7 +468,7 @@ func TestSessionBadge_IdleWithDuplicates(t *testing.T) {
 		UpdatedAt: time.Now().Add(-25 * time.Minute),
 	}
 	badge := sessionBadge(session, 3)
-	if !strings.Contains(badge, "⚠️ idle") {
+	if !strings.Contains(badge, "💤 idle") {
 		t.Fatalf("expected idle badge, got %q", badge)
 	}
 	if !strings.Contains(badge, "(+3 older)") {


### PR DESCRIPTION
The ATTENTION tab now only shows sessions genuinely waiting on you:

**Before**: ATTENTION = needs-input + failed + idle 20min-4h (noisy)
**After**: ATTENTION = needs-input + failed only (signal)

Idle sessions get a calm `💤 idle ~23m` badge — informational, not alarming. No more `⚠️` for sessions that are just slow.

### Changes
- `SessionNeedsAttention()` simplified to only needs-input/failed
- Idle badge: `💤 idle ~Xm` (was `⚠️ idle ~Xm — check logs`)
- Detail view: attention reason only for needs-input/failed
- Quiet duplicate detection uses idle threshold directly

Closes #117