### PR TITLE
feat: smart default tab selection on startup

### DIFF
--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -170,6 +170,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.toast.Push(StatusIcon(s.Status), s.Title, prev+" → "+s.Status)
 				}
 			}
+		} else {
+			// First load: pick the best default tab based on actual data
+			m.ctx.StatusFilter = smartDefaultFilter(msg.counts)
+			m.taskList.SetLoading(true)
+			m.prevSessions = make(map[string]string, len(msg.tasks))
+			for _, s := range msg.tasks {
+				m.prevSessions[s.ID] = s.Status
+			}
+			return m, m.fetchTasks
 		}
 		// Update prevSessions for next comparison
 		m.prevSessions = make(map[string]string, len(msg.tasks))
@@ -756,6 +765,17 @@ func isValidFilter(filter string) bool {
 	default:
 		return false
 	}
+}
+
+// smartDefaultFilter picks the best starting tab based on actual session counts.
+func smartDefaultFilter(counts FilterCounts) string {
+	if counts.Attention > 0 {
+		return "attention"
+	}
+	if counts.Active > 0 {
+		return "active"
+	}
+	return "all"
 }
 
 // previewVisible returns true when the split-pane detail preview should render.


### PR DESCRIPTION
On first load, picks the tab that actually has content:

1. **ATTENTION** — if there are needs-input/failed sessions
2. **RUNNING** — if there are active sessions  
3. **ALL** — fallback

Avoids the awkward experience of landing on an empty ATTENTION tab showing "All quiet out here" while sessions exist on other tabs.