### PR TITLE
feat: add tool execution timeline view

### DIFF
--- a/internal/tui/components/tooltimeline/tooltimeline.go
+++ b/internal/tui/components/tooltimeline/tooltimeline.go
@@ -1,0 +1,169 @@
+package tooltimeline
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ToolEvent represents a single tool execution in the timeline
+type ToolEvent struct {
+	Timestamp string
+	ToolName  string
+	Icon      string
+}
+
+// Model holds the state of the tool timeline view
+type Model struct {
+	events   []ToolEvent
+	viewport viewport.Model
+	width    int
+	height   int
+	ready    bool
+}
+
+// New creates a new tool timeline model
+func New(width, height int) Model {
+	vp := viewport.New(width, height)
+	return Model{
+		viewport: vp,
+		width:    width,
+		height:   height,
+	}
+}
+
+// SetEvents replaces the current events and re-renders
+func (m *Model) SetEvents(events []ToolEvent) {
+	m.events = events
+	m.viewport.SetContent(m.renderTimeline())
+	m.ready = true
+}
+
+// SetSize updates the viewport dimensions
+func (m *Model) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+	m.viewport.Width = width
+	m.viewport.Height = height
+	if m.ready {
+		m.viewport.SetContent(m.renderTimeline())
+	}
+}
+
+// Update handles messages for viewport scrolling
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.viewport, cmd = m.viewport.Update(msg)
+	return m, cmd
+}
+
+// View renders the timeline inside a bordered box
+func (m Model) View() string {
+	if !m.ready || len(m.events) == 0 {
+		boxStyle := lipgloss.NewStyle().
+			BorderStyle(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("238")).
+			Padding(1, 2).
+			Width(m.width - 4)
+		title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("99")).Render("Tool Timeline")
+		return boxStyle.Render(title + "\n\nNo tool executions recorded.")
+	}
+
+	return m.viewport.View()
+}
+
+// LineDown scrolls down one line
+func (m *Model) LineDown() { m.viewport.ScrollDown(1) }
+
+// LineUp scrolls up one line
+func (m *Model) LineUp() { m.viewport.ScrollUp(1) }
+
+// HalfPageDown scrolls down half a page
+func (m *Model) HalfPageDown() { m.viewport.HalfPageDown() }
+
+// HalfPageUp scrolls up half a page
+func (m *Model) HalfPageUp() { m.viewport.HalfPageUp() }
+
+func (m *Model) renderTimeline() string {
+	if len(m.events) == 0 {
+		return ""
+	}
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("99"))
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	iconStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
+
+	innerWidth := m.width - 8
+	if innerWidth < 20 {
+		innerWidth = 20
+	}
+
+	var lines []string
+	var prevTime string
+	for _, ev := range m.events {
+		ts := formatTimelineTimestamp(ev.Timestamp)
+
+		// Group rapid sequences: dim the timestamp if same as previous
+		tsDisplay := dimStyle.Render(ts)
+		if ts == prevTime {
+			tsDisplay = dimStyle.Render("  ·  ")
+		}
+		prevTime = ts
+
+		line := fmt.Sprintf("  %s  %s %s",
+			tsDisplay,
+			iconStyle.Render(ev.Icon),
+			ev.ToolName,
+		)
+		lines = append(lines, line)
+	}
+
+	content := strings.Join(lines, "\n")
+
+	boxStyle := lipgloss.NewStyle().
+		BorderStyle(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("238")).
+		Padding(1, 2).
+		Width(m.width - 4)
+
+	header := titleStyle.Render("Tool Timeline") +
+		dimStyle.Render(fmt.Sprintf("  (%d executions)", len(m.events)))
+
+	return boxStyle.Render(header + "\n\n" + content)
+}
+
+func formatTimelineTimestamp(ts string) string {
+	t, err := time.Parse(time.RFC3339Nano, ts)
+	if err != nil {
+		t, err = time.Parse(time.RFC3339, ts)
+		if err != nil {
+			return ts
+		}
+	}
+	return t.Format("15:04")
+}
+
+// ToolIcon returns an emoji icon for a tool name
+func ToolIcon(name string) string {
+	lower := strings.ToLower(name)
+	switch {
+	case strings.Contains(lower, "bash"), strings.Contains(lower, "terminal"):
+		return "🔧"
+	case strings.Contains(lower, "edit"), strings.Contains(lower, "write"), strings.Contains(lower, "create"):
+		return "✏️"
+	case strings.Contains(lower, "read"), strings.Contains(lower, "view"), strings.Contains(lower, "file"):
+		return "📄"
+	case strings.Contains(lower, "grep"), strings.Contains(lower, "search"), strings.Contains(lower, "glob"):
+		return "🔍"
+	case strings.Contains(lower, "git"), strings.Contains(lower, "commit"):
+		return "📤"
+	case strings.Contains(lower, "test"):
+		return "🧪"
+	default:
+		return "⚙️"
+	}
+}

--- a/internal/tui/components/tooltimeline/tooltimeline_test.go
+++ b/internal/tui/components/tooltimeline/tooltimeline_test.go
@@ -1,0 +1,147 @@
+package tooltimeline
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestToolIcon_Bash(t *testing.T) {
+	if icon := ToolIcon("bash"); icon != "🔧" {
+		t.Errorf("expected 🔧 for bash, got %s", icon)
+	}
+	if icon := ToolIcon("run_terminal_command"); icon != "🔧" {
+		t.Errorf("expected 🔧 for run_terminal_command, got %s", icon)
+	}
+}
+
+func TestToolIcon_Edit(t *testing.T) {
+	if icon := ToolIcon("edit_file"); icon != "✏️" {
+		t.Errorf("expected ✏️ for edit_file, got %s", icon)
+	}
+	if icon := ToolIcon("write"); icon != "✏️" {
+		t.Errorf("expected ✏️ for write, got %s", icon)
+	}
+	if icon := ToolIcon("create_file"); icon != "✏️" {
+		t.Errorf("expected ✏️ for create_file, got %s", icon)
+	}
+}
+
+func TestToolIcon_Read(t *testing.T) {
+	if icon := ToolIcon("read_file"); icon != "📄" {
+		t.Errorf("expected 📄 for read_file, got %s", icon)
+	}
+	if icon := ToolIcon("view"); icon != "📄" {
+		t.Errorf("expected 📄 for view, got %s", icon)
+	}
+}
+
+func TestToolIcon_Search(t *testing.T) {
+	if icon := ToolIcon("grep"); icon != "🔍" {
+		t.Errorf("expected 🔍 for grep, got %s", icon)
+	}
+	if icon := ToolIcon("search_code"); icon != "🔍" {
+		t.Errorf("expected 🔍 for search_code, got %s", icon)
+	}
+	if icon := ToolIcon("glob"); icon != "🔍" {
+		t.Errorf("expected 🔍 for glob, got %s", icon)
+	}
+}
+
+func TestToolIcon_Git(t *testing.T) {
+	if icon := ToolIcon("git_commit"); icon != "📤" {
+		t.Errorf("expected 📤 for git_commit, got %s", icon)
+	}
+}
+
+func TestToolIcon_Test(t *testing.T) {
+	if icon := ToolIcon("run_test"); icon != "🧪" {
+		t.Errorf("expected 🧪 for run_test, got %s", icon)
+	}
+}
+
+func TestToolIcon_Default(t *testing.T) {
+	if icon := ToolIcon("unknown_tool"); icon != "⚙️" {
+		t.Errorf("expected ⚙️ for unknown_tool, got %s", icon)
+	}
+}
+
+func TestToolIcon_CaseInsensitive(t *testing.T) {
+	if icon := ToolIcon("BASH"); icon != "🔧" {
+		t.Errorf("expected 🔧 for BASH, got %s", icon)
+	}
+}
+
+func TestNew(t *testing.T) {
+	m := New(80, 24)
+	if m.width != 80 || m.height != 24 {
+		t.Errorf("expected 80x24, got %dx%d", m.width, m.height)
+	}
+}
+
+func TestSetEvents_Empty(t *testing.T) {
+	m := New(80, 24)
+	m.SetEvents(nil)
+	view := m.View()
+	if !strings.Contains(view, "No tool executions") {
+		t.Errorf("expected empty state message, got: %s", view)
+	}
+}
+
+func TestSetEvents_WithEvents(t *testing.T) {
+	m := New(80, 24)
+	events := []ToolEvent{
+		{Timestamp: "2025-01-15T09:15:00Z", ToolName: "grep", Icon: "🔍"},
+		{Timestamp: "2025-01-15T09:15:30Z", ToolName: "view", Icon: "📄"},
+		{Timestamp: "2025-01-15T09:16:00Z", ToolName: "edit", Icon: "✏️"},
+	}
+	m.SetEvents(events)
+	view := m.View()
+	if !strings.Contains(view, "Tool Timeline") {
+		t.Errorf("expected 'Tool Timeline' in view, got: %s", view)
+	}
+	if !strings.Contains(view, "3 executions") {
+		t.Errorf("expected '3 executions' in view, got: %s", view)
+	}
+	if !strings.Contains(view, "grep") {
+		t.Errorf("expected 'grep' in view, got: %s", view)
+	}
+}
+
+func TestSetSize(t *testing.T) {
+	m := New(80, 24)
+	m.SetSize(120, 40)
+	if m.width != 120 || m.height != 40 {
+		t.Errorf("expected 120x40, got %dx%d", m.width, m.height)
+	}
+}
+
+func TestFormatTimelineTimestamp(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"2025-01-15T09:15:00Z", "09:15"},
+		{"2025-01-15T14:30:45.123Z", "14:30"},
+		{"invalid", "invalid"},
+	}
+	for _, tt := range tests {
+		result := formatTimelineTimestamp(tt.input)
+		if result != tt.expected {
+			t.Errorf("formatTimelineTimestamp(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestRapidSequenceGrouping(t *testing.T) {
+	m := New(80, 24)
+	events := []ToolEvent{
+		{Timestamp: "2025-01-15T09:15:00Z", ToolName: "grep", Icon: "🔍"},
+		{Timestamp: "2025-01-15T09:15:30Z", ToolName: "view", Icon: "📄"},
+	}
+	m.SetEvents(events)
+	view := m.View()
+	// Both share the same 09:15 minute — second should show dot grouping
+	if !strings.Contains(view, "·") {
+		t.Errorf("expected rapid-sequence dot grouping, got: %s", view)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a chronological tool execution timeline view accessible via the `t` key from the detail view for local Copilot sessions.

## Changes

### New component: `internal/tui/components/tooltimeline/`
- Renders a scrollable, bordered timeline of tool executions
- Each tool gets a category icon (🔧 bash, ✏️ edit, 📄 read, 🔍 search, 📤 git, 🧪 test, ⚙️ default)
- Timestamps are formatted as `HH:MM`; rapid sequences within the same minute are visually grouped with `·`
- Supports viewport scrolling (j/k, d/u)

### Data layer: `FetchSessionEvents()` in `internal/data/localsession.go`
- Parses `events.jsonl` into structured `SessionEvent` records
- Extracts `toolName` from `tool.execution_start` events and `content` from message events
- Reusable by other features that need structured event access

### Integration in `internal/tui/ui.go`
- New `ViewModeToolTimeline` view mode
- `t` key in detail view opens timeline (only for local-copilot sessions with events)
- `esc` returns to detail view
- Footer shows `t tools` hint in detail view when applicable

### Tests
- Icon mapping for all tool categories + case insensitivity
- Empty state rendering
- Event rendering with count display
- Rapid-sequence grouping
- Timestamp formatting

Closes #123