### PR TITLE
feat: add conversation view with styled chat bubbles

### DIFF
--- a/internal/data/localsession_test.go
+++ b/internal/data/localsession_test.go
@@ -630,6 +630,47 @@ func TestFetchLocalSessionLog_EmptyID(t *testing.T) {
 	}
 }
 
+func TestFetchSessionEvents_EmptyID(t *testing.T) {
+	_, err := FetchSessionEvents("")
+	if err == nil {
+		t.Fatal("expected error for empty session ID")
+	}
+}
+
+func TestFetchSessionEvents_MissingSession(t *testing.T) {
+	_, err := FetchSessionEvents("nonexistent-session-id-99999")
+	if err == nil {
+		t.Fatal("expected error for missing session")
+	}
+}
+
+func TestFetchSessionEvents_ParsesEvents(t *testing.T) {
+	// We can't easily mock the home dir for FetchSessionEvents without
+	// modifying its signature, so test the underlying parsing logic
+	// by verifying the event types we expect are returned from the
+	// formatting functions and that the struct fields are set correctly.
+	ev := SessionEvent{
+		Type:      "user.message",
+		Timestamp: "2026-01-15T10:30:01.000Z",
+		Role:      "user",
+		Content:   "fix the bug please",
+	}
+	if ev.Role != "user" {
+		t.Errorf("expected role 'user', got %q", ev.Role)
+	}
+	if ev.Content != "fix the bug please" {
+		t.Errorf("unexpected content: %q", ev.Content)
+	}
+
+	toolEv := SessionEvent{
+		Type:     "tool.execution_start",
+		ToolName: "bash",
+	}
+	if toolEv.ToolName != "bash" {
+		t.Errorf("expected tool name 'bash', got %q", toolEv.ToolName)
+	}
+}
+
 func TestFetchLocalSessionLog_ValidEvents(t *testing.T) {
 	// Create a temp session directory with events.jsonl
 	tmpDir := t.TempDir()

--- a/internal/tui/components/conversation/conversation.go
+++ b/internal/tui/components/conversation/conversation.go
@@ -1,0 +1,310 @@
+package conversation
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// MessageRole identifies who sent a chat message.
+type MessageRole string
+
+const (
+	RoleUser      MessageRole = "user"
+	RoleAssistant MessageRole = "assistant"
+	RoleSystem    MessageRole = "system"
+)
+
+// ChatMessage is a single message in the conversation timeline.
+type ChatMessage struct {
+	Role      MessageRole
+	Content   string
+	Timestamp string
+	Tools     []string // tool names used during this turn
+}
+
+// Model is the Bubble Tea model for the conversation view.
+type Model struct {
+	messages []ChatMessage
+	viewport viewport.Model
+	width    int
+	height   int
+	ready    bool
+}
+
+// New creates a new conversation view model.
+func New(width, height int) Model {
+	vp := viewport.New(width, height)
+	return Model{
+		viewport: vp,
+		width:    width,
+		height:   height,
+	}
+}
+
+// SetMessages replaces the displayed messages and re-renders.
+func (m *Model) SetMessages(messages []ChatMessage) {
+	m.messages = messages
+	m.renderContent()
+}
+
+// SetSize updates the component dimensions.
+func (m *Model) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+	m.viewport.Width = width
+	m.viewport.Height = height
+	if m.ready {
+		m.renderContent()
+	}
+}
+
+// Update handles Bubble Tea messages (viewport passthrough).
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.viewport, cmd = m.viewport.Update(msg)
+	return m, cmd
+}
+
+// View renders the conversation.
+func (m Model) View() string {
+	if !m.ready || len(m.messages) == 0 {
+		return lipgloss.NewStyle().Faint(true).Render("No conversation messages")
+	}
+	return m.viewport.View()
+}
+
+// Scrolling helpers
+
+func (m *Model) LineUp()       { m.viewport.ScrollUp(1) }
+func (m *Model) LineDown()     { m.viewport.ScrollDown(1) }
+func (m *Model) HalfPageUp()   { m.viewport.HalfPageUp() }
+func (m *Model) HalfPageDown() { m.viewport.HalfPageDown() }
+func (m *Model) GotoTop()      { m.viewport.GotoTop() }
+func (m *Model) GotoBottom()   { m.viewport.GotoBottom() }
+
+// ---- rendering ----
+
+// renderContent builds the full conversation view and pushes it into the viewport.
+func (m *Model) renderContent() {
+	if len(m.messages) == 0 {
+		m.ready = true
+		return
+	}
+
+	bubbleWidth := m.bubbleWidth()
+	var sections []string
+	var prevTime time.Time
+
+	for _, msg := range m.messages {
+		// Insert timestamp separator when gap > 5 minutes
+		if ts, ok := parseTimestamp(msg.Timestamp); ok {
+			if !prevTime.IsZero() && ts.Sub(prevTime) > 5*time.Minute {
+				sep := renderTimeSeparator(ts, m.width)
+				sections = append(sections, sep)
+			}
+			prevTime = ts
+		}
+
+		switch msg.Role {
+		case RoleUser:
+			sections = append(sections, renderUserBubble(msg, bubbleWidth))
+		case RoleAssistant:
+			sections = append(sections, renderAgentBubble(msg, bubbleWidth, m.width))
+		case RoleSystem:
+			sections = append(sections, renderSystemBubble(msg, m.width))
+		}
+	}
+
+	m.viewport.SetContent(strings.Join(sections, "\n\n"))
+	m.ready = true
+}
+
+func (m *Model) bubbleWidth() int {
+	w := m.width * 65 / 100
+	if w < 40 {
+		w = m.width - 4
+	}
+	if w < 10 {
+		w = 10
+	}
+	return w
+}
+
+// ---- bubble renderers ----
+
+var (
+	userBorderStyle = lipgloss.NewStyle().
+			BorderStyle(lipgloss.ThickBorder()).
+			BorderLeft(true).
+			BorderRight(false).
+			BorderTop(false).
+			BorderBottom(false).
+			BorderForeground(lipgloss.AdaptiveColor{Light: "27", Dark: "69"}).
+			PaddingLeft(1)
+
+	agentBorderStyle = lipgloss.NewStyle().
+				BorderStyle(lipgloss.ThickBorder()).
+				BorderLeft(false).
+				BorderRight(true).
+				BorderTop(false).
+				BorderBottom(false).
+				BorderForeground(lipgloss.AdaptiveColor{Light: "28", Dark: "42"}).
+				PaddingRight(1)
+
+	headerStyle = lipgloss.NewStyle().Bold(true)
+
+	timestampStyle = lipgloss.NewStyle().Faint(true)
+
+	toolStyle = lipgloss.NewStyle().Faint(true)
+
+	separatorStyle = lipgloss.NewStyle().Faint(true).Align(lipgloss.Center)
+)
+
+func renderUserBubble(msg ChatMessage, bubbleWidth int) string {
+	ts := formatShortTimestamp(msg.Timestamp)
+
+	hdr := headerStyle.Render("You")
+	if ts != "" {
+		pad := bubbleWidth - lipgloss.Width(hdr) - lipgloss.Width(ts) - 2
+		if pad < 1 {
+			pad = 1
+		}
+		hdr = hdr + strings.Repeat(" ", pad) + timestampStyle.Render(ts)
+	}
+
+	body := wordWrap(msg.Content, bubbleWidth-2)
+	inner := hdr + "\n" + body
+
+	return userBorderStyle.Width(bubbleWidth).Render(inner)
+}
+
+func renderAgentBubble(msg ChatMessage, bubbleWidth, totalWidth int) string {
+	ts := formatShortTimestamp(msg.Timestamp)
+
+	hdr := headerStyle.Render("Agent")
+	if ts != "" {
+		pad := bubbleWidth - lipgloss.Width(hdr) - lipgloss.Width(ts) - 2
+		if pad < 1 {
+			pad = 1
+		}
+		hdr = hdr + strings.Repeat(" ", pad) + timestampStyle.Render(ts)
+	}
+
+	body := wordWrap(msg.Content, bubbleWidth-2)
+
+	// Append tool line if any
+	if len(msg.Tools) > 0 {
+		body += "\n" + toolStyle.Render(formatToolLine(msg.Tools))
+	}
+
+	inner := hdr + "\n" + body
+	bubble := agentBorderStyle.Width(bubbleWidth).Render(inner)
+
+	// Right-align: indent from left
+	indent := totalWidth - lipgloss.Width(bubble)
+	if indent < 0 {
+		indent = 0
+	}
+	return lipgloss.NewStyle().PaddingLeft(indent).Render(bubble)
+}
+
+func renderSystemBubble(msg ChatMessage, totalWidth int) string {
+	text := "⚡ " + msg.Content
+	return separatorStyle.Width(totalWidth).Render(text)
+}
+
+func renderTimeSeparator(ts time.Time, totalWidth int) string {
+	text := fmt.Sprintf("── %s ──", ts.Format("15:04"))
+	return separatorStyle.Width(totalWidth).Render(text)
+}
+
+// ---- tool formatting ----
+
+var toolIcons = map[string]string{
+	"bash":   "🔧",
+	"edit":   "✏️",
+	"grep":   "🔍",
+	"view":   "👁️",
+	"create": "📄",
+	"glob":   "🔍",
+}
+
+func formatToolLine(tools []string) string {
+	seen := make(map[string]bool)
+	var parts []string
+	for _, t := range tools {
+		if seen[t] {
+			continue
+		}
+		seen[t] = true
+		icon, ok := toolIcons[t]
+		if !ok {
+			icon = "🔧"
+		}
+		parts = append(parts, icon+" "+t)
+	}
+	return strings.Join(parts, " • ")
+}
+
+// ---- helpers ----
+
+func parseTimestamp(ts string) (time.Time, bool) {
+	layouts := []string{time.RFC3339Nano, time.RFC3339}
+	for _, l := range layouts {
+		if t, err := time.Parse(l, ts); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func formatShortTimestamp(ts string) string {
+	if t, ok := parseTimestamp(ts); ok {
+		return t.Format("15:04")
+	}
+	return ""
+}
+
+// wordWrap performs a simple word wrap at maxWidth.
+func wordWrap(s string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return s
+	}
+	var result strings.Builder
+	for _, line := range strings.Split(s, "\n") {
+		if lipgloss.Width(line) <= maxWidth {
+			if result.Len() > 0 {
+				result.WriteByte('\n')
+			}
+			result.WriteString(line)
+			continue
+		}
+		words := strings.Fields(line)
+		cur := ""
+		for _, w := range words {
+			if cur == "" {
+				cur = w
+			} else if lipgloss.Width(cur+" "+w) <= maxWidth {
+				cur += " " + w
+			} else {
+				if result.Len() > 0 {
+					result.WriteByte('\n')
+				}
+				result.WriteString(cur)
+				cur = w
+			}
+		}
+		if cur != "" {
+			if result.Len() > 0 {
+				result.WriteByte('\n')
+			}
+			result.WriteString(cur)
+		}
+	}
+	return result.String()
+}

--- a/internal/tui/components/conversation/conversation_test.go
+++ b/internal/tui/components/conversation/conversation_test.go
@@ -1,0 +1,185 @@
+package conversation
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	m := New(80, 24)
+	if m.width != 80 || m.height != 24 {
+		t.Errorf("expected 80x24, got %dx%d", m.width, m.height)
+	}
+}
+
+func TestSetMessages_Empty(t *testing.T) {
+	m := New(80, 24)
+	m.SetMessages(nil)
+	view := m.View()
+	if !strings.Contains(view, "No conversation messages") {
+		t.Errorf("expected empty state message, got %q", view)
+	}
+}
+
+func TestSetMessages_UserMessage(t *testing.T) {
+	m := New(80, 24)
+	m.SetMessages([]ChatMessage{
+		{Role: RoleUser, Content: "Fix the auth bug", Timestamp: "2026-01-15T09:15:00Z"},
+	})
+	view := m.View()
+	if !strings.Contains(view, "You") {
+		t.Error("expected 'You' header in user message")
+	}
+	if !strings.Contains(view, "Fix the auth bug") {
+		t.Error("expected message content in output")
+	}
+}
+
+func TestSetMessages_AgentMessage(t *testing.T) {
+	m := New(80, 24)
+	m.SetMessages([]ChatMessage{
+		{Role: RoleAssistant, Content: "I'll fix it", Timestamp: "2026-01-15T09:15:00Z", Tools: []string{"bash", "edit"}},
+	})
+	view := m.View()
+	if !strings.Contains(view, "Agent") {
+		t.Error("expected 'Agent' header in assistant message")
+	}
+	if !strings.Contains(view, "I'll fix it") {
+		t.Error("expected message content in output")
+	}
+	if !strings.Contains(view, "bash") || !strings.Contains(view, "edit") {
+		t.Error("expected tool names in output")
+	}
+}
+
+func TestSetMessages_MultipleTurns(t *testing.T) {
+	m := New(100, 30)
+	m.SetMessages([]ChatMessage{
+		{Role: RoleUser, Content: "Hello", Timestamp: "2026-01-15T09:15:00Z"},
+		{Role: RoleAssistant, Content: "Hi there!", Timestamp: "2026-01-15T09:15:05Z"},
+		{Role: RoleUser, Content: "Now add tests", Timestamp: "2026-01-15T09:17:00Z"},
+	})
+	view := m.View()
+	if strings.Count(view, "You") < 2 {
+		t.Error("expected two user messages")
+	}
+	if !strings.Contains(view, "Agent") {
+		t.Error("expected agent message")
+	}
+}
+
+func TestTimeSeparator_LargeGap(t *testing.T) {
+	m := New(80, 40)
+	m.SetMessages([]ChatMessage{
+		{Role: RoleUser, Content: "First", Timestamp: "2026-01-15T09:00:00Z"},
+		{Role: RoleUser, Content: "Second", Timestamp: "2026-01-15T09:10:00Z"},
+	})
+	view := m.View()
+	// 10 minute gap > 5 minute threshold, so separator should appear
+	if !strings.Contains(view, "09:10") {
+		t.Error("expected time separator for 10-minute gap")
+	}
+}
+
+func TestTimeSeparator_SmallGap(t *testing.T) {
+	m := New(80, 40)
+	m.SetMessages([]ChatMessage{
+		{Role: RoleUser, Content: "First", Timestamp: "2026-01-15T09:00:00Z"},
+		{Role: RoleUser, Content: "Second", Timestamp: "2026-01-15T09:02:00Z"},
+	})
+	view := m.View()
+	// 2 minute gap < 5 minute threshold — no separator with the time between messages
+	// The timestamps still appear in the bubble headers
+	lines := strings.Split(view, "\n")
+	separatorFound := false
+	for _, line := range lines {
+		if strings.Contains(line, "──") && strings.Contains(line, "09:02") {
+			separatorFound = true
+		}
+	}
+	if separatorFound {
+		t.Error("did not expect time separator for 2-minute gap")
+	}
+}
+
+func TestSetSize(t *testing.T) {
+	m := New(80, 24)
+	m.SetMessages([]ChatMessage{
+		{Role: RoleUser, Content: "hello", Timestamp: "2026-01-15T09:00:00Z"},
+	})
+	m.SetSize(120, 40)
+	if m.width != 120 || m.height != 40 {
+		t.Errorf("expected 120x40, got %dx%d", m.width, m.height)
+	}
+	// Should still render after resize
+	view := m.View()
+	if !strings.Contains(view, "hello") {
+		t.Error("expected content after resize")
+	}
+}
+
+func TestScrolling(t *testing.T) {
+	m := New(80, 5) // Small viewport to force scrolling
+	var msgs []ChatMessage
+	for i := 0; i < 20; i++ {
+		msgs = append(msgs, ChatMessage{
+			Role:      RoleUser,
+			Content:   "Line of chat content for scrolling test",
+			Timestamp: "2026-01-15T09:00:00Z",
+		})
+	}
+	m.SetMessages(msgs)
+
+	// These should not panic
+	m.LineDown()
+	m.LineUp()
+	m.HalfPageDown()
+	m.HalfPageUp()
+	m.GotoBottom()
+	m.GotoTop()
+}
+
+func TestSystemMessage(t *testing.T) {
+	m := New(80, 24)
+	m.SetMessages([]ChatMessage{
+		{Role: RoleSystem, Content: "Session started", Timestamp: "2026-01-15T09:00:00Z"},
+	})
+	view := m.View()
+	if !strings.Contains(view, "Session started") {
+		t.Error("expected system message content")
+	}
+}
+
+func TestFormatToolLine(t *testing.T) {
+	line := formatToolLine([]string{"bash", "edit", "grep"})
+	if !strings.Contains(line, "bash") || !strings.Contains(line, "edit") || !strings.Contains(line, "grep") {
+		t.Errorf("expected all tools in line, got %q", line)
+	}
+	if !strings.Contains(line, "•") {
+		t.Error("expected bullet separator between tools")
+	}
+}
+
+func TestFormatToolLine_Dedup(t *testing.T) {
+	line := formatToolLine([]string{"bash", "bash", "edit"})
+	if strings.Count(line, "bash") != 1 {
+		t.Error("expected duplicate tools to be deduplicated")
+	}
+}
+
+func TestWordWrap(t *testing.T) {
+	result := wordWrap("hello world this is a test", 10)
+	lines := strings.Split(result, "\n")
+	for _, l := range lines {
+		if len(l) > 12 { // some slack for word boundaries
+			t.Errorf("line too long: %q", l)
+		}
+	}
+}
+
+func TestWordWrap_PreservesNewlines(t *testing.T) {
+	result := wordWrap("line1\nline2", 80)
+	if !strings.Contains(result, "line1") || !strings.Contains(result, "line2") {
+		t.Error("expected both lines preserved")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a conversation view mode to the log viewer that renders user/agent messages as styled chat bubbles instead of raw markdown.

### Changes

- **New component**: `internal/tui/components/conversation/` — Bubble Tea component that renders chat messages as styled bubbles with lipgloss
  - User messages: left-aligned with colored left border, "You" header
  - Agent messages: right-aligned with colored right border, "Agent" header  
  - Tool executions: compact inline display (🔧 bash • ✏️ edit • 🔍 grep)
  - Time separators: centered dimmed timestamp when gap > 5 minutes between messages
  - Full viewport scrolling support

- **Data layer**: `FetchSessionEvents()` in `internal/data/localsession.go` — parses `events.jsonl` into structured `SessionEvent` structs with full (untruncated) content

- **UI integration**: Press `c` in log view to toggle between raw log and conversation view (local-copilot sessions only). Footer shows `c convo` hint.

### Testing

- `conversation_test.go`: rendering, scrolling, time separators, empty state, tool deduplication, word wrap
- `localsession_test.go`: `FetchSessionEvents` error cases and struct validation

Closes #125