### PR TITLE
feat: add mission control dashboard view

### DIFF
--- a/internal/tui/components/mission/mission.go
+++ b/internal/tui/components/mission/mission.go
@@ -1,0 +1,267 @@
+package mission
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/maxbeizer/gh-agent-viz/internal/data"
+)
+
+// SessionCard pairs a session with its derived last-action text.
+type SessionCard struct {
+	Session    data.Session
+	LastAction string
+}
+
+// Model represents the mission control dashboard state.
+type Model struct {
+	cards          []SessionCard
+	cursor         int
+	statusIcon     func(string) string
+	animStatusIcon func(string, int) string
+	animFrame      int
+	width          int
+	height         int
+	titleStyle     lipgloss.Style
+	cardStyle      lipgloss.Style
+	cardSelStyle   lipgloss.Style
+}
+
+// New creates a new mission control model.
+func New(
+	titleStyle lipgloss.Style,
+	cardStyle lipgloss.Style,
+	cardSelStyle lipgloss.Style,
+	statusIconFunc func(string) string,
+	animStatusIconFunc func(string, int) string,
+) Model {
+	return Model{
+		statusIcon:     statusIconFunc,
+		animStatusIcon: animStatusIconFunc,
+		titleStyle:     titleStyle,
+		cardStyle:      cardStyle,
+		cardSelStyle:   cardSelStyle,
+		width:          80,
+		height:         24,
+	}
+}
+
+// SetSessions populates the dashboard cards from sessions.
+func (m *Model) SetSessions(sessions []data.Session) {
+	m.cards = make([]SessionCard, len(sessions))
+	for i, s := range sessions {
+		m.cards[i] = SessionCard{
+			Session:    s,
+			LastAction: DeriveLastAction(s),
+		}
+	}
+	m.clampCursor()
+}
+
+// SetSize sets the available rendering dimensions.
+func (m *Model) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+}
+
+// SetAnimFrame updates the animation frame counter.
+func (m *Model) SetAnimFrame(frame int) {
+	m.animFrame = frame
+}
+
+// MoveCursor moves the cursor by delta.
+func (m *Model) MoveCursor(delta int) {
+	if len(m.cards) == 0 {
+		return
+	}
+	m.cursor += delta
+	m.clampCursor()
+}
+
+// Cursor returns the current cursor position (for testing).
+func (m *Model) Cursor() int {
+	return m.cursor
+}
+
+// Cards returns the current cards (for testing).
+func (m *Model) Cards() []SessionCard {
+	return m.cards
+}
+
+// SelectedSession returns a pointer to the currently selected session, or nil.
+func (m *Model) SelectedSession() *data.Session {
+	if len(m.cards) == 0 || m.cursor < 0 || m.cursor >= len(m.cards) {
+		return nil
+	}
+	s := m.cards[m.cursor].Session
+	return &s
+}
+
+// View renders the mission control dashboard.
+func (m *Model) View() string {
+	if len(m.cards) == 0 {
+		return m.titleStyle.Render("  No sessions to display")
+	}
+
+	var lines []string
+	for i, card := range m.cards {
+		isSelected := i == m.cursor
+		lines = append(lines, m.renderCard(card, isSelected))
+		// Separator between cards
+		if i < len(m.cards)-1 {
+			sep := strings.Repeat("─", m.cardWidth())
+			lines = append(lines, lipgloss.NewStyle().Foreground(lipgloss.Color("238")).Render("  "+sep))
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func (m *Model) cardWidth() int {
+	w := m.width - 4
+	if w < 40 {
+		w = 40
+	}
+	return w
+}
+
+func (m *Model) renderCard(card SessionCard, selected bool) string {
+	s := card.Session
+	w := m.cardWidth()
+
+	icon := m.statusIcon(s.Status)
+	if m.animStatusIcon != nil {
+		icon = m.animStatusIcon(s.Status, m.animFrame)
+	}
+
+	// Line 1: icon + title + repo + duration (right-aligned)
+	title := s.Title
+	repo := s.Repository
+	if repo == "" {
+		repo = "local"
+	}
+	rightInfo := formatDuration(s)
+
+	// Compute available width for title
+	// "  {icon} {title}  {repo}  {rightInfo}"
+	fixedLen := 2 + runeWidth(icon) + 1 + 2 + len(repo) + 2 + len(rightInfo)
+	maxTitle := w - fixedLen
+	if maxTitle < 5 {
+		maxTitle = 5
+	}
+	if len(title) > maxTitle {
+		title = title[:maxTitle-1] + "…"
+	}
+
+	left := fmt.Sprintf("  %s %s", icon, title)
+	right := fmt.Sprintf("%s  %s", repo, rightInfo)
+	padding := w - runeWidth(left) - len(right)
+	if padding < 2 {
+		padding = 2
+	}
+	line1 := left + strings.Repeat(" ", padding) + right
+
+	// Line 2: action (indented, dimmed)
+	action := card.LastAction
+	maxAction := w - 4
+	if maxAction < 10 {
+		maxAction = 10
+	}
+	if len(action) > maxAction {
+		action = action[:maxAction-1] + "…"
+	}
+	actionStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	line2 := "    " + actionStyle.Render(action)
+
+	cardText := line1 + "\n" + line2
+
+	if selected {
+		return m.cardSelStyle.Width(w + 4).Render(cardText)
+	}
+	return m.cardStyle.Width(w + 4).Render(cardText)
+}
+
+func (m *Model) clampCursor() {
+	if len(m.cards) == 0 {
+		m.cursor = 0
+		return
+	}
+	if m.cursor < 0 {
+		m.cursor = 0
+	}
+	if m.cursor >= len(m.cards) {
+		m.cursor = len(m.cards) - 1
+	}
+}
+
+// runeWidth is a simple approximation for display width.
+func runeWidth(s string) int {
+	return len([]rune(s))
+}
+
+// formatDuration returns a concise duration or status label for the session.
+func formatDuration(s data.Session) string {
+	status := strings.ToLower(strings.TrimSpace(s.Status))
+	switch status {
+	case "completed":
+		return "done"
+	case "failed":
+		return "failed"
+	case "queued":
+		return "queued"
+	}
+	if s.CreatedAt.IsZero() {
+		return ""
+	}
+	d := time.Since(s.CreatedAt)
+	switch {
+	case d < time.Minute:
+		return "⏱ <1m"
+	case d < time.Hour:
+		return fmt.Sprintf("⏱ %dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("⏱ %dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("⏱ %dd", int(d.Hours()/24))
+	}
+}
+
+// DeriveLastAction returns a brief description of what the session is currently doing.
+func DeriveLastAction(s data.Session) string {
+	status := strings.ToLower(strings.TrimSpace(s.Status))
+
+	switch status {
+	case "queued":
+		return "⏳ Waiting to start"
+	case "failed":
+		return "❌ Session failed"
+	case "completed":
+		if s.PRNumber > 0 {
+			return fmt.Sprintf("📤 PR #%d ready for review", s.PRNumber)
+		}
+		return "✅ Completed"
+	case "needs-input":
+		// For local sessions, try to get the last assistant message
+		if s.Source == data.SourceLocalCopilot {
+			if msg := data.FetchLastAssistantMessage(s.ID); msg != "" {
+				truncated := msg
+				if len(truncated) > 80 {
+					truncated = truncated[:77] + "..."
+				}
+				return "❓ \"" + truncated + "\""
+			}
+		}
+		return "🧑 Waiting for input"
+	case "running":
+		if s.Source == data.SourceLocalCopilot {
+			if action := data.FetchLastSessionAction(s); action != "" {
+				return action
+			}
+		}
+		return "● Working..."
+	default:
+		return "● Working..."
+	}
+}

--- a/internal/tui/components/mission/mission_test.go
+++ b/internal/tui/components/mission/mission_test.go
@@ -1,0 +1,253 @@
+package mission
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/maxbeizer/gh-agent-viz/internal/data"
+)
+
+func plainIcon(status string) string {
+	switch status {
+	case "running":
+		return "●"
+	case "queued":
+		return "○"
+	case "completed":
+		return "✅"
+	case "failed":
+		return "❌"
+	case "needs-input":
+		return "🧑"
+	default:
+		return "⚪"
+	}
+}
+
+func newTestModel() Model {
+	title := lipgloss.NewStyle()
+	card := lipgloss.NewStyle()
+	cardSel := lipgloss.NewStyle().Bold(true)
+	return New(title, card, cardSel, plainIcon, nil)
+}
+
+func TestSetSessions(t *testing.T) {
+	m := newTestModel()
+	sessions := []data.Session{
+		{ID: "1", Status: "running", Title: "Fix auth bug", Repository: "owner/repo"},
+		{ID: "2", Status: "completed", Title: "Update docs", Repository: "owner/docs"},
+	}
+	m.SetSessions(sessions)
+
+	if len(m.Cards()) != 2 {
+		t.Fatalf("expected 2 cards, got %d", len(m.Cards()))
+	}
+	if m.Cards()[0].Session.Title != "Fix auth bug" {
+		t.Fatalf("expected first card title 'Fix auth bug', got %q", m.Cards()[0].Session.Title)
+	}
+}
+
+func TestCursorNavigation(t *testing.T) {
+	m := newTestModel()
+	sessions := []data.Session{
+		{ID: "1", Status: "running", Title: "One"},
+		{ID: "2", Status: "running", Title: "Two"},
+		{ID: "3", Status: "running", Title: "Three"},
+	}
+	m.SetSessions(sessions)
+
+	if m.Cursor() != 0 {
+		t.Fatalf("expected initial cursor 0, got %d", m.Cursor())
+	}
+
+	m.MoveCursor(1)
+	if m.Cursor() != 1 {
+		t.Fatalf("expected cursor 1 after down, got %d", m.Cursor())
+	}
+
+	m.MoveCursor(1)
+	if m.Cursor() != 2 {
+		t.Fatalf("expected cursor 2 after second down, got %d", m.Cursor())
+	}
+
+	// Should clamp at end
+	m.MoveCursor(1)
+	if m.Cursor() != 2 {
+		t.Fatalf("expected cursor clamped at 2, got %d", m.Cursor())
+	}
+
+	m.MoveCursor(-1)
+	if m.Cursor() != 1 {
+		t.Fatalf("expected cursor 1 after up, got %d", m.Cursor())
+	}
+
+	// Should clamp at start
+	m.MoveCursor(-5)
+	if m.Cursor() != 0 {
+		t.Fatalf("expected cursor clamped at 0, got %d", m.Cursor())
+	}
+}
+
+func TestCursorNavigationEmpty(t *testing.T) {
+	m := newTestModel()
+	m.SetSessions(nil)
+
+	m.MoveCursor(1)
+	if m.Cursor() != 0 {
+		t.Fatalf("expected cursor 0 on empty, got %d", m.Cursor())
+	}
+}
+
+func TestSelectedSession(t *testing.T) {
+	m := newTestModel()
+	sessions := []data.Session{
+		{ID: "1", Status: "running", Title: "First"},
+		{ID: "2", Status: "completed", Title: "Second"},
+	}
+	m.SetSessions(sessions)
+
+	s := m.SelectedSession()
+	if s == nil || s.ID != "1" {
+		t.Fatal("expected selected session to be first")
+	}
+
+	m.MoveCursor(1)
+	s = m.SelectedSession()
+	if s == nil || s.ID != "2" {
+		t.Fatal("expected selected session to be second after cursor move")
+	}
+}
+
+func TestSelectedSessionEmpty(t *testing.T) {
+	m := newTestModel()
+	m.SetSessions(nil)
+	if m.SelectedSession() != nil {
+		t.Fatal("expected nil on empty")
+	}
+}
+
+func TestViewEmpty(t *testing.T) {
+	m := newTestModel()
+	m.SetSessions(nil)
+	view := m.View()
+	if !strings.Contains(view, "No sessions") {
+		t.Fatalf("expected empty state text, got %q", view)
+	}
+}
+
+func TestViewRendersCards(t *testing.T) {
+	m := newTestModel()
+	m.SetSize(100, 30)
+	sessions := []data.Session{
+		{ID: "1", Status: "running", Title: "Fix auth bug", Repository: "owner/repo", CreatedAt: time.Now().Add(-12 * time.Minute)},
+		{ID: "2", Status: "completed", Title: "Update docs", Repository: "owner/docs", PRNumber: 42},
+	}
+	m.SetSessions(sessions)
+
+	view := m.View()
+
+	if !strings.Contains(view, "Fix auth bug") {
+		t.Fatal("expected running session title in view")
+	}
+	if !strings.Contains(view, "Update docs") {
+		t.Fatal("expected completed session title in view")
+	}
+	if !strings.Contains(view, "owner/repo") {
+		t.Fatal("expected repo in view")
+	}
+	// Should have separator between cards
+	if !strings.Contains(view, "───") {
+		t.Fatal("expected separator between cards")
+	}
+}
+
+func TestDeriveLastAction_Queued(t *testing.T) {
+	s := data.Session{Status: "queued"}
+	action := DeriveLastAction(s)
+	if action != "⏳ Waiting to start" {
+		t.Fatalf("expected queued action, got %q", action)
+	}
+}
+
+func TestDeriveLastAction_Failed(t *testing.T) {
+	s := data.Session{Status: "failed"}
+	action := DeriveLastAction(s)
+	if action != "❌ Session failed" {
+		t.Fatalf("expected failed action, got %q", action)
+	}
+}
+
+func TestDeriveLastAction_CompletedNoPR(t *testing.T) {
+	s := data.Session{Status: "completed"}
+	action := DeriveLastAction(s)
+	if action != "✅ Completed" {
+		t.Fatalf("expected completed action, got %q", action)
+	}
+}
+
+func TestDeriveLastAction_CompletedWithPR(t *testing.T) {
+	s := data.Session{Status: "completed", PRNumber: 42}
+	action := DeriveLastAction(s)
+	if action != "📤 PR #42 ready for review" {
+		t.Fatalf("expected PR action, got %q", action)
+	}
+}
+
+func TestDeriveLastAction_Running(t *testing.T) {
+	s := data.Session{Status: "running", Source: data.SourceAgentTask}
+	action := DeriveLastAction(s)
+	if action != "● Working..." {
+		t.Fatalf("expected working action, got %q", action)
+	}
+}
+
+func TestDeriveLastAction_NeedsInput(t *testing.T) {
+	s := data.Session{Status: "needs-input", Source: data.SourceAgentTask}
+	action := DeriveLastAction(s)
+	if action != "🧑 Waiting for input" {
+		t.Fatalf("expected needs-input action, got %q", action)
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		name   string
+		s      data.Session
+		expect string
+	}{
+		{"completed", data.Session{Status: "completed"}, "done"},
+		{"failed", data.Session{Status: "failed"}, "failed"},
+		{"queued", data.Session{Status: "queued"}, "queued"},
+		{"zero time", data.Session{Status: "running"}, ""},
+		{"recent", data.Session{Status: "running", CreatedAt: time.Now().Add(-30 * time.Second)}, "⏱ <1m"},
+		{"minutes", data.Session{Status: "running", CreatedAt: time.Now().Add(-12 * time.Minute)}, "⏱ 12m"},
+		{"hours", data.Session{Status: "running", CreatedAt: time.Now().Add(-3 * time.Hour)}, "⏱ 3h"},
+		{"days", data.Session{Status: "running", CreatedAt: time.Now().Add(-48 * time.Hour)}, "⏱ 2d"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatDuration(tt.s)
+			if got != tt.expect {
+				t.Fatalf("expected %q, got %q", tt.expect, got)
+			}
+		})
+	}
+}
+
+func TestAnimFrameUpdates(t *testing.T) {
+	m := newTestModel()
+	m.SetAnimFrame(5)
+	if m.animFrame != 5 {
+		t.Fatalf("expected animFrame 5, got %d", m.animFrame)
+	}
+}
+
+func TestSetSize(t *testing.T) {
+	m := newTestModel()
+	m.SetSize(120, 40)
+	if m.width != 120 || m.height != 40 {
+		t.Fatalf("expected 120x40, got %dx%d", m.width, m.height)
+	}
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -21,6 +21,7 @@ type Keybindings struct {
 	ExpandGroup    key.Binding
 	ToggleFollow   key.Binding
 	ToggleKanban   key.Binding
+	ToggleMission  key.Binding
 	ShowHelp       key.Binding
 }
 
@@ -94,6 +95,10 @@ func NewKeybindings() Keybindings {
 		ToggleKanban: key.NewBinding(
 			key.WithKeys("K"),
 			key.WithHelp("K", "kanban"),
+		),
+		ToggleMission: key.NewBinding(
+			key.WithKeys("M"),
+			key.WithHelp("M", "mission"),
 		),
 		ShowHelp: key.NewBinding(
 			key.WithKeys("?"),


### PR DESCRIPTION
## Summary

Adds a compact live-updating **mission control dashboard** — like btop for coding agents.

Press **M** from the list view to toggle the dashboard. Each session is rendered as a card showing:

- **Line 1**: Status icon + title + repository + duration/status (right-aligned)
- **Line 2**: Current action (dimmed) — derived from the session's last event or status
- **Separator** between cards

### Action derivation heuristics

| Status | Action shown |
|---|---|
| `queued` | ⏳ Waiting to start |
| `running` (local) | 🔧 last tool name from events.jsonl |
| `running` (other) | ● Working... |
| `needs-input` (local) | ❓ last assistant question |
| `needs-input` (other) | 🧑 Waiting for input |
| `completed` + PR | 📤 PR #N ready for review |
| `completed` | ✅ Completed |
| `failed` | ❌ Session failed |

### Files changed

- `internal/tui/components/mission/mission.go` — new dashboard component
- `internal/tui/components/mission/mission_test.go` — tests for rendering, cursor nav, action derivation
- `internal/data/localsession.go` — `FetchLastSessionAction` and `FetchLastAssistantMessage` helpers
- `internal/tui/keys.go` — `ToggleMission` keybinding (`M`)
- `internal/tui/ui.go` — `ViewModeMission`, wiring into Update/View/key handlers/footer

### Navigation in mission view

- `j/k` — navigate between cards
- `enter` — open detail view for selected session
- `esc` or `M` — back to list view
- `r` — refresh

Closes #126