### PR TITLE
fix: enter expands collapsed groups, c key works from list/detail

### DIFF
--- a/internal/tui/components/help/help.go
+++ b/internal/tui/components/help/help.go
@@ -69,7 +69,11 @@ func (m Model) View() string {
 	// Views section
 	views := sectionStyle.Render("Views") + "\n" +
 		formatKey("K", "kanban board") + "\n" +
+		formatKey("M", "mission control") + "\n" +
 		formatKey("l", "logs") + "\n" +
+		formatKey("c", "conversation") + "\n" +
+		formatKey("t", "tool timeline") + "\n" +
+		formatKey("d", "diff (PR)") + "\n" +
 		formatKey("p", "preview pane")
 
 	// Groups section

--- a/internal/tui/components/tasklist/tasklist.go
+++ b/internal/tui/components/tasklist/tasklist.go
@@ -712,6 +712,26 @@ func (m Model) IsGrouped() bool {
 	return !m.userSetGroupBy && len(m.sessions) >= autoGroupThreshold
 }
 
+// IsCursorOnCollapsedGroup returns true when the cursor is on a collapsed group header.
+func (m Model) IsCursorOnCollapsedGroup() bool {
+	gb := m.effectiveGroupBy()
+	if gb == "" {
+		return false
+	}
+	groups := m.buildGroupsWith(gb)
+	for gi, g := range groups {
+		if gi == m.expandedGroup {
+			continue // expanded group — cursor is on a session row
+		}
+		for _, idx := range g.sessions {
+			if idx == m.rowCursor {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // effectiveGroupBy returns the active groupBy mode (manual or auto).
 func (m Model) effectiveGroupBy() string {
 	if m.groupBy != "" {

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -423,6 +423,11 @@ func (m Model) handleListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "k", "up":
 		m.taskList.MoveCursor(-1)
 	case "enter":
+		// If cursor is on a collapsed group header, expand it instead of opening detail
+		if m.taskList.IsCursorOnCollapsedGroup() {
+			m.taskList.ToggleGroupExpand()
+			return m, nil
+		}
 		session := m.taskList.SelectedTask()
 		if session != nil {
 			if session.Source == data.SourceLocalCopilot {
@@ -445,6 +450,13 @@ func (m Model) handleListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, m.fetchTaskLog(session.ID, session.Repository)
 		}
+case "c":
+session := m.taskList.SelectedTask()
+if session != nil && session.Source == data.SourceLocalCopilot && session.HasLog {
+m.viewMode = ViewModeLog
+m.showConversation = true
+return m, m.fetchConversation(session.ID)
+}
 	case "o":
 		session := m.taskList.SelectedTask()
 		if session != nil {
@@ -512,6 +524,13 @@ func (m Model) handleDetailKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, m.fetchTaskLog(session.ID, session.Repository)
 		}
+case "c":
+session := m.taskList.SelectedTask()
+if session != nil && session.Source == data.SourceLocalCopilot && session.HasLog {
+m.viewMode = ViewModeLog
+m.showConversation = true
+return m, m.fetchConversation(session.ID)
+}
 	case "o":
 		session := m.taskList.SelectedTask()
 		if session != nil {


### PR DESCRIPTION
Two bug fixes:

**#132 — Enter on collapsed group header**: Was opening detail for a hidden session. Now expands the group (same as space). Added `IsCursorOnCollapsedGroup()` method.

**#131 — Conversation view discoverability**: `c` key now works from list view and detail view (was only available inside log view). Also updated the `?` help overlay with all new views (M mission, c conversation, t tools, d diff).

Closes #131
Closes #132