### PR TITLE
fix: revert tinted row backgrounds, add random startup tagline

### DIFF
--- a/internal/tui/components/header/header.go
+++ b/internal/tui/components/header/header.go
@@ -2,10 +2,27 @@ package header
 
 import (
 	"fmt"
+	"math/rand"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 )
+
+// taglines displayed randomly on startup
+var taglines = []string{
+	"your agents, at a glance",
+	"be in control of your agents",
+	"mission control for AI",
+	"keeping an eye on things",
+	"agents assemble",
+	"who's working on what?",
+	"the command center",
+	"all systems nominal",
+	"orchestrate everything",
+	"let them cook",
+	"while you were away...",
+	"dispatch, monitor, ship",
+}
 
 // FilterCounts holds per-filter session counts for the tab bar
 type FilterCounts struct {
@@ -23,6 +40,7 @@ type Model struct {
 	tabInactive    lipgloss.Style
 	tabCount       lipgloss.Style
 	title          string
+	tagline        string
 	filter         *string
 	counts         FilterCounts
 	useAsciiHeader bool
@@ -47,6 +65,7 @@ func New(titleStyle, tabActive, tabInactive, tabCount lipgloss.Style, title stri
 		tabInactive:    tabInactive,
 		tabCount:       tabCount,
 		title:          title,
+		tagline:        taglines[rand.Intn(len(taglines))],
 		filter:         filter,
 		useAsciiHeader: useAsciiHeader,
 		width:          80,
@@ -108,10 +127,19 @@ func (m Model) View() string {
 		Foreground(lipgloss.AdaptiveColor{Light: "249", Dark: "240"}).
 		Render(strings.Repeat("━", m.width))
 
-	if m.showBanner() {
-		styledBanner := m.titleStyle.Render(Banner)
-		return styledBanner + "\n" + tabLine + "\n" + separator + "\n"
+	taglineRendered := ""
+	if m.tagline != "" && m.height >= 18 {
+		taglineRendered = "\n" + lipgloss.NewStyle().
+			Faint(true).
+			Italic(true).
+			Padding(0, 2).
+			Render(m.tagline)
 	}
 
-	return tabLine + "\n" + separator + "\n"
+	if m.showBanner() {
+		styledBanner := m.titleStyle.Render(Banner)
+		return styledBanner + "\n" + tabLine + taglineRendered + "\n" + separator + "\n"
+	}
+
+	return tabLine + taglineRendered + "\n" + separator + "\n"
 }

--- a/internal/tui/components/tasklist/tasklist.go
+++ b/internal/tui/components/tasklist/tasklist.go
@@ -168,7 +168,7 @@ func (m Model) renderFocusedList() string {
 func (m Model) renderRow(sessionIdx int, session data.Session, selected bool, width int) string {
 	style := m.tableRowStyle
 	if selected {
-		style = m.statusSelectedStyle(session.Status)
+		style = m.tableRowSelected
 	}
 
 	icon := m.currentStatusIcon(session.Status)
@@ -911,23 +911,6 @@ func (m Model) statusColor(status string) lipgloss.Color {
 		return lipgloss.Color("203")
 	default:
 		return lipgloss.Color("245")
-	}
-}
-
-// statusSelectedStyle returns a row style tinted by status color.
-func (m Model) statusSelectedStyle(status string) lipgloss.Style {
-	base := m.tableRowSelected
-	switch strings.ToLower(strings.TrimSpace(status)) {
-	case "running":
-		return base.Background(lipgloss.Color("22"))
-	case "needs-input":
-		return base.Background(lipgloss.Color("94"))
-	case "failed":
-		return base.Background(lipgloss.Color("52"))
-	case "completed":
-		return base.Background(lipgloss.Color("23"))
-	default:
-		return base
 	}
 }
 


### PR DESCRIPTION
Two changes:

**Revert tinted rows** — removes the status-colored selected-row backgrounds (green/red/amber). Keeps the warmer palette, dimmed meta lines, and everything else from the visual overhaul.

**Random tagline** — adds a random phrase below the header on each launch (faint italic, hidden on small terminals). Pool of 12 phrases like "let them cook", "mission control for AI", "dispatch, monitor, ship".

Closes #135