### PR TITLE
fix: vertically center tagline beside banner box

### DIFF
--- a/internal/tui/components/header/header.go
+++ b/internal/tui/components/header/header.go
@@ -131,7 +131,8 @@ func (m Model) View() string {
 		styledBanner := m.titleStyle.Render(Banner)
 		if m.tagline != "" {
 			tagStyle := lipgloss.NewStyle().Faint(true).Italic(true)
-			styledBanner += "  " + tagStyle.Render(m.tagline)
+			tagBlock := tagStyle.Render(m.tagline)
+			styledBanner = lipgloss.JoinHorizontal(lipgloss.Center, styledBanner, "  ", tagBlock)
 		}
 		return styledBanner + "\n" + tabLine + "\n" + separator + "\n"
 	}


### PR DESCRIPTION
Uses `lipgloss.JoinHorizontal` to render the tagline beside the banner box, vertically centered, instead of appended below.