### PR TITLE
fix: improve tagline readability — no background bleed

### DIFF
--- a/internal/tui/components/header/header.go
+++ b/internal/tui/components/header/header.go
@@ -128,9 +128,14 @@ func (m Model) View() string {
 		Render(strings.Repeat("━", m.width))
 
 	if m.showBanner() {
-		styledBanner := m.titleStyle.Render(Banner)
+		bannerStyle := lipgloss.NewStyle().
+			Bold(true).
+			Foreground(m.titleStyle.GetForeground())
+		styledBanner := bannerStyle.Render(Banner)
 		if m.tagline != "" {
-			tagStyle := lipgloss.NewStyle().Faint(true).Italic(true)
+			tagStyle := lipgloss.NewStyle().
+				Foreground(lipgloss.AdaptiveColor{Light: "245", Dark: "250"}).
+				Italic(true)
 			tagBlock := tagStyle.Render(m.tagline)
 			styledBanner = lipgloss.JoinHorizontal(lipgloss.Center, styledBanner, "  ", tagBlock)
 		}


### PR DESCRIPTION
Banner now renders without titleStyle padding/background. Tagline uses a plain light color (250 dark / 245 light) instead of faint, making it clearly readable.