### PR TITLE
feat: reorder tabs — RUNNING first, ATTENTION last

### DIFF
--- a/internal/tui/components/header/header.go
+++ b/internal/tui/components/header/header.go
@@ -103,11 +103,11 @@ func (m Model) View() string {
 		label string
 		count int
 	}{
-		{"attention", "ATTENTION", m.counts.Attention},
 		{"active", "RUNNING", m.counts.Active},
 		{"completed", "DONE", m.counts.Completed},
 		{"failed", "FAILED", m.counts.Failed},
 		{"all", "ALL", m.counts.All},
+		{"attention", "ATTENTION", m.counts.Attention},
 	}
 
 	renderedTabs := make([]string, 0, len(tabs))

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -722,7 +722,7 @@ func (m Model) handleMissionKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 // cycleFilter cycles through status filters by delta (+1 forward, -1 backward)
 func (m *Model) cycleFilter(delta int) {
-	filters := []string{"attention", "active", "completed", "failed", "all"}
+	filters := []string{"active", "completed", "failed", "all", "attention"}
 	for i, f := range filters {
 		if f == m.ctx.StatusFilter {
 			next := (i + delta) % len(filters)
@@ -1058,11 +1058,11 @@ func isValidFilter(filter string) bool {
 
 // smartDefaultFilter picks the best starting tab based on actual session counts.
 func smartDefaultFilter(counts FilterCounts) string {
-	if counts.Attention > 0 {
-		return "attention"
-	}
 	if counts.Active > 0 {
 		return "active"
+	}
+	if counts.Attention > 0 {
+		return "attention"
 	}
 	return "all"
 }


### PR DESCRIPTION
RUNNING is the most useful default now that ATTENTION only fires for needs-input/failed. Moves ATTENTION to the end of the tab bar and updates the cycle order and smart default to match.