### PR TITLE
fix: start on RUNNING tab to prevent startup flash

### DIFF
--- a/internal/tui/context.go
+++ b/internal/tui/context.go
@@ -28,6 +28,6 @@ func NewProgramContext() *ProgramContext {
 		Config:       config.DefaultConfig(),
 		Width:        80,
 		Height:       24,
-		StatusFilter: "attention",
+		StatusFilter: "active",
 	}
 }


### PR DESCRIPTION
Initial StatusFilter was 'attention', causing a visible flash before smartDefaultFilter switched it on first data load. Now defaults to 'active' so the app starts on RUNNING immediately.

Closes #142