### PR TITLE
feat: subtler animation + kanban columns rework

### DIFF
--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -354,30 +354,16 @@ func StatusIcon(status string) string {
 	}
 }
 
-// Pulsing dot frames for running sessions — solid → ring → hollow → ring → solid
-var runningFrames = []string{"●", "●", "◉", "○", "◉", "●"}
+// Running sessions: steady dot, gentle color breathing between two close greens
+var runningColors = []string{"42", "42", "42", "36", "36", "42"}
 
-// Gentle waiting frames for queued sessions
-var queuedFrames = []string{"◌", "○", "◎", "○"}
-
-// AnimatedStatusIcon returns an animated icon for running/queued statuses,
-// or the static icon for all other statuses. The frame parameter selects
-// which animation frame to display and cycles color intensity.
+// AnimatedStatusIcon returns a subtly animated icon for running sessions.
+// Queued and other statuses use their static icon — only "in progress"
+// sessions get the gentle color pulse.
 func AnimatedStatusIcon(status string, frame int) string {
-	switch status {
-	case "running":
-		f := runningFrames[frame%len(runningFrames)]
-		// Cycle between bright and dim green
-		colors := []string{"42", "34", "28", "34", "42", "42"}
-		color := colors[frame%len(colors)]
-		return lipgloss.NewStyle().Foreground(lipgloss.Color(color)).Render(f)
-	case "queued":
-		f := queuedFrames[frame%len(queuedFrames)]
-		// Cycle through amber tones
-		colors := []string{"226", "220", "214", "220"}
-		color := colors[frame%len(colors)]
-		return lipgloss.NewStyle().Foreground(lipgloss.Color(color)).Render(f)
-	default:
-		return StatusIcon(status)
+	if status == "running" {
+		color := runningColors[frame%len(runningColors)]
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(color)).Render("●")
 	}
+	return StatusIcon(status)
 }

--- a/internal/tui/theme_test.go
+++ b/internal/tui/theme_test.go
@@ -123,39 +123,35 @@ func TestNewThemeFromConfig_UnknownFallsBackToDefault(t *testing.T) {
 }
 
 func TestAnimatedStatusIcon_Running(t *testing.T) {
-	// Frame 0 should contain the first pulsing dot character
+	// All frames should contain the steady dot
 	icon := AnimatedStatusIcon("running", 0)
 	if !strings.Contains(icon, "●") {
 		t.Errorf("expected ● in running frame 0, got %q", icon)
 	}
-	// Frame 2 should contain the ring character
-	icon = AnimatedStatusIcon("running", 2)
-	if !strings.Contains(icon, "◉") {
-		t.Errorf("expected ◉ in running frame 2, got %q", icon)
+	icon = AnimatedStatusIcon("running", 3)
+	if !strings.Contains(icon, "●") {
+		t.Errorf("expected ● in running frame 3, got %q", icon)
 	}
 }
 
 func TestAnimatedStatusIcon_Queued(t *testing.T) {
+	// Queued now uses static icon (no animation)
 	icon := AnimatedStatusIcon("queued", 0)
-	if !strings.Contains(icon, "◌") {
-		t.Errorf("expected ◌ in queued frame 0, got %q", icon)
-	}
-	icon = AnimatedStatusIcon("queued", 1)
 	if !strings.Contains(icon, "○") {
-		t.Errorf("expected ○ in queued frame 1, got %q", icon)
+		t.Errorf("expected ○ in queued frame 0, got %q", icon)
 	}
 }
 
 func TestAnimatedStatusIcon_WrapsFrames(t *testing.T) {
-	// Frame 6 should wrap to frame 0 for running (6 frames)
+	// Frame 6 should wrap and still show ●
 	icon := AnimatedStatusIcon("running", 6)
 	if !strings.Contains(icon, "●") {
 		t.Errorf("expected ● for running frame 6 (wrap), got %q", icon)
 	}
-	// Frame 4 should wrap to frame 0 for queued (4 frames)
+	// Queued is static now
 	icon = AnimatedStatusIcon("queued", 4)
-	if !strings.Contains(icon, "◌") {
-		t.Errorf("expected ◌ for queued frame 4 (wrap), got %q", icon)
+	if !strings.Contains(icon, "○") {
+		t.Errorf("expected ○ for queued (static), got %q", icon)
 	}
 }
 


### PR DESCRIPTION
Two changes:

**Subtler animation**: Running sessions show a steady `●` with gentle green color breathing (ANSI 42↔36). No shape changes, no queued animation. Only running sessions animate.

**Kanban columns**: Simplified from 4 columns to 3 that match the user's mental model:
- **IN PROGRESS** — actively working (running/queued/needs-input, updated < 20min)
- **IDLE** — running but quiet 20+ minutes
- **DONE** — completed + failed