### PR TITLE
fix: idle animation, kanban done column, selected row background

### DIFF
--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -70,7 +70,6 @@ func newDefaultTheme() *Theme {
 			Padding(0, 1),
 		TableRowSelected: lipgloss.NewStyle().
 			Padding(0, 1).
-			Background(lipgloss.Color("236")).
 			Foreground(lipgloss.Color("15")).
 			Bold(true),
 		Border: lipgloss.NewStyle().
@@ -130,7 +129,6 @@ func newAdaptiveDefaultTheme() *Theme {
 			Foreground(lipgloss.AdaptiveColor{Light: "236", Dark: "252"}),
 		TableRowSelected: lipgloss.NewStyle().
 			Padding(0, 1).
-			Background(lipgloss.AdaptiveColor{Light: "254", Dark: "235"}).
 			Foreground(lipgloss.AdaptiveColor{Light: "0", Dark: "255"}).
 			Bold(true),
 		Border: lipgloss.NewStyle().
@@ -186,7 +184,6 @@ func newCatppuccinMochaTheme() *Theme {
 			Foreground(lipgloss.Color("#cdd6f4")),
 		TableRowSelected: lipgloss.NewStyle().
 			Padding(0, 1).
-			Background(lipgloss.Color("#313244")).
 			Foreground(lipgloss.Color("#cdd6f4")).
 			Bold(true),
 		Border: lipgloss.NewStyle().
@@ -242,7 +239,6 @@ func newDraculaTheme() *Theme {
 			Foreground(lipgloss.Color("#f8f8f2")),
 		TableRowSelected: lipgloss.NewStyle().
 			Padding(0, 1).
-			Background(lipgloss.Color("#44475a")).
 			Foreground(lipgloss.Color("#f8f8f2")).
 			Bold(true),
 		Border: lipgloss.NewStyle().
@@ -298,7 +294,6 @@ func newTokyoNightTheme() *Theme {
 			Foreground(lipgloss.Color("#c0caf5")),
 		TableRowSelected: lipgloss.NewStyle().
 			Padding(0, 1).
-			Background(lipgloss.Color("#33467c")).
 			Foreground(lipgloss.Color("#c0caf5")).
 			Bold(true),
 		Border: lipgloss.NewStyle().

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -180,9 +180,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		})
 		m.taskList.SetLoading(false)
 		m.taskList.SetTasks(msg.tasks)
-		m.taskDetail.SetAllSessions(msg.tasks)
-		m.kanban.SetSessions(msg.tasks)
-		m.mission.SetSessions(msg.tasks)
+		m.taskDetail.SetAllSessions(msg.allSessions)
+		m.kanban.SetSessions(msg.allSessions)
+		m.mission.SetSessions(msg.allSessions)
 
 		// Detect status changes and push toasts (skip first load)
 		if m.prevSessions != nil {
@@ -738,8 +738,9 @@ func (m *Model) cycleFilter(delta int) {
 
 // Message types
 type tasksLoadedMsg struct {
-	tasks  []data.Session
-	counts FilterCounts
+	tasks       []data.Session
+	allSessions []data.Session // unfiltered, for kanban/mission
+	counts      FilterCounts
 }
 
 type taskDetailLoadedMsg struct {
@@ -829,7 +830,7 @@ func (m Model) fetchTasks() tea.Msg {
 		sessions = filtered
 	}
 
-	return tasksLoadedMsg{sessions, counts}
+	return tasksLoadedMsg{sessions, visible, counts}
 }
 
 // fetchTaskDetail fetches detailed information for a session


### PR DESCRIPTION
Three fixes:

1. **Idle sessions don't animate** — only sessions updated < 20min get the green breathing. Idle sessions show a static `●`.
2. **Kanban DONE column works** — kanban and mission control now receive all sessions, not just the filtered tab's subset.
3. **No background on selected rows** — selection indicated by bold + gutter bar only. Cleaner look across all themes.