### PR TITLE
fix: stop animating idle sessions in kanban and mission control

### DIFF
--- a/internal/tui/components/kanban/kanban.go
+++ b/internal/tui/components/kanban/kanban.go
@@ -51,6 +51,19 @@ func statusBelongsToColumn(session data.Session, colStatus string) bool {
 	return false
 }
 
+// isActiveNotIdle returns true for sessions actively working (not idle 20+ min)
+func isActiveNotIdle(session data.Session) bool {
+	s := strings.ToLower(strings.TrimSpace(session.Status))
+	isActive := s == "running" || s == "active" || s == "queued" || s == "needs-input"
+	if !isActive {
+		return false
+	}
+	if session.UpdatedAt.IsZero() {
+		return true
+	}
+	return time.Since(session.UpdatedAt) < data.AttentionStaleThreshold
+}
+
 // Model represents the kanban board state
 type Model struct {
 	columns           []Column
@@ -284,7 +297,7 @@ func (m *Model) renderColumn(col Column, colIdx, width, cardAreaHeight int, focu
 // renderCard renders a single session card.
 func (m *Model) renderCard(session data.Session, width int, selected bool) string {
 	icon := m.statusIcon(session.Status)
-	if m.animStatusIcon != nil {
+	if m.animStatusIcon != nil && isActiveNotIdle(session) {
 		icon = m.animStatusIcon(session.Status, m.animFrame)
 	}
 


### PR DESCRIPTION
Kanban and mission control were still pulsing green for idle sessions. Now all views use the same idle check — only sessions updated < 20min animate.