### PR TITLE
fix: remove redundant Agent Sessions title from header

### DIFF
--- a/internal/tui/components/header/header.go
+++ b/internal/tui/components/header/header.go
@@ -91,8 +91,6 @@ func (m Model) showBanner() bool {
 
 // View renders the header as a tab bar
 func (m Model) View() string {
-	title := m.titleStyle.Render(m.title)
-
 	activeFilter := "attention"
 	if m.filter != nil && *m.filter != "" {
 		activeFilter = *m.filter
@@ -121,7 +119,7 @@ func (m Model) View() string {
 	}
 
 	tabBar := strings.Join(renderedTabs, "")
-	tabLine := lipgloss.JoinHorizontal(lipgloss.Center, title, "  ", tabBar)
+	tabLine := tabBar
 
 	separator := lipgloss.NewStyle().
 		Foreground(lipgloss.AdaptiveColor{Light: "249", Dark: "240"}).
@@ -145,7 +143,7 @@ func (m Model) View() string {
 	// No banner: show tagline beside the title
 	if m.tagline != "" && m.height >= 18 {
 		tagStyle := lipgloss.NewStyle().Faint(true).Italic(true)
-		tabLine = lipgloss.JoinHorizontal(lipgloss.Center, title, "  ", tagStyle.Render(m.tagline), "  ", tabBar)
+		tabLine = lipgloss.JoinHorizontal(lipgloss.Center, tagStyle.Render(m.tagline), "  ", tabBar)
 	}
 
 	return tabLine + "\n" + separator + "\n"

--- a/internal/tui/components/header/header_test.go
+++ b/internal/tui/components/header/header_test.go
@@ -42,14 +42,12 @@ func TestNew_NilFilter(t *testing.T) {
 	}
 }
 
-func TestView_RendersTitle(t *testing.T) {
-	title := "My Application"
-
-	model := newTestModel(title, nil)
+func TestView_RendersTabs(t *testing.T) {
+	model := newTestModel("My Application", nil)
 	view := model.View()
 
-	if !strings.Contains(view, title) {
-		t.Errorf("expected view to contain title '%s', got: %s", title, view)
+	if !strings.Contains(view, "RUNNING") {
+		t.Errorf("expected view to contain RUNNING tab, got: %s", view)
 	}
 }
 
@@ -61,9 +59,6 @@ func TestView_WithFilter(t *testing.T) {
 	model.SetCounts(FilterCounts{All: 5, Completed: 2})
 	view := model.View()
 
-	if !strings.Contains(view, title) {
-		t.Errorf("expected view to contain title '%s'", title)
-	}
 	// Active tab should be highlighted
 	if !strings.Contains(view, "DONE") {
 		t.Errorf("expected view to contain DONE tab for completed filter, got: %s", view)
@@ -114,15 +109,14 @@ func TestView_BannerRendersWhenEnabled(t *testing.T) {
 }
 
 func TestView_PlainTitleWhenBannerDisabled(t *testing.T) {
-	title := "⚡ Agent Sessions"
-	model := newTestModelWithBanner(title, nil, false)
+	model := newTestModelWithBanner("⚡ Agent Sessions", nil, false)
 	view := model.View()
 
 	if strings.Contains(view, "A G E N T   V I Z") {
 		t.Error("expected view NOT to contain ASCII banner when disabled")
 	}
-	if !strings.Contains(view, title) {
-		t.Errorf("expected view to contain plain title '%s'", title)
+	if !strings.Contains(view, "RUNNING") {
+		t.Errorf("expected view to contain tabs when banner is disabled, got: %s", view)
 	}
 }
 


### PR DESCRIPTION
Removes the '⚡ Agent Sessions' text from beside the tab bar. The ASCII banner already identifies the app.

Closes #147