### PR TITLE
feat: add ! and @ shortcuts to view repo and file issues

### DIFF
--- a/internal/tui/components/help/help.go
+++ b/internal/tui/components/help/help.go
@@ -87,6 +87,11 @@ func (m Model) View() string {
 		formatKey("g/G", "top/bottom") + "\n" +
 		formatKey("f", "toggle follow")
 
+	// Meta section
+	meta := sectionStyle.Render("Meta") + "\n" +
+		formatKey("!", "view source repo") + "\n" +
+		formatKey("@", "file an issue")
+
 	// Layout: two columns for Navigation+Actions, Views+Groups
 	colWidth := 28
 	col := func(content string) string {
@@ -95,8 +100,9 @@ func (m Model) View() string {
 
 	topRow := lipgloss.JoinHorizontal(lipgloss.Top, col(nav), col(actions))
 	midRow := lipgloss.JoinHorizontal(lipgloss.Top, col(views), col(groups))
+	botRow := lipgloss.JoinHorizontal(lipgloss.Top, col(logView), col(meta))
 
-	body := strings.Join([]string{topRow, midRow, logView}, "\n\n")
+	body := strings.Join([]string{topRow, midRow, botRow}, "\n\n")
 
 	closeHint := dimStyle.Render("Press ? or esc to close")
 	body += "\n\n" + lipgloss.NewStyle().Width(colWidth*2).Align(lipgloss.Center).Render(closeHint)

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -24,6 +24,8 @@ type Keybindings struct {
 	ToggleMission  key.Binding
 	ShowDiff       key.Binding
 	ShowHelp       key.Binding
+	OpenRepo       key.Binding
+	FileIssue      key.Binding
 }
 
 // NewKeybindings creates the default key bindings for the TUI
@@ -108,6 +110,14 @@ func NewKeybindings() Keybindings {
 		ShowHelp: key.NewBinding(
 			key.WithKeys("?"),
 			key.WithHelp("?", "help"),
+		),
+		OpenRepo: key.NewBinding(
+			key.WithKeys("!"),
+			key.WithHelp("!", "repo"),
+		),
+		FileIssue: key.NewBinding(
+			key.WithKeys("@"),
+			key.WithHelp("@", "file issue"),
 		),
 	}
 }

--- a/internal/tui/keys_test.go
+++ b/internal/tui/keys_test.go
@@ -1,0 +1,25 @@
+package tui
+
+import "testing"
+
+func TestKeybindings_OpenRepoExists(t *testing.T) {
+	kb := NewKeybindings()
+	keys := kb.OpenRepo.Keys()
+	if len(keys) == 0 {
+		t.Fatal("expected OpenRepo to have keys")
+	}
+	if keys[0] != "!" {
+		t.Fatalf("expected OpenRepo key to be '!', got %q", keys[0])
+	}
+}
+
+func TestKeybindings_FileIssueExists(t *testing.T) {
+	kb := NewKeybindings()
+	keys := kb.FileIssue.Keys()
+	if len(keys) == 0 {
+		t.Fatal("expected FileIssue to have keys")
+	}
+	if keys[0] != "@" {
+		t.Fatalf("expected FileIssue key to be '@', got %q", keys[0])
+	}
+}

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -504,6 +504,10 @@ return m, m.fetchConversation(session.ID)
 		m.viewMode = ViewModeMission
 		m.mission.SetSize(m.ctx.Width, m.ctx.Height-4)
 		return m, nil
+	case "!":
+		return m, m.openSourceRepo()
+	case "@":
+		return m, m.openFileIssue()
 	}
 	return m, nil
 }
@@ -942,6 +946,26 @@ func (m Model) fetchConversation(sessionID string) tea.Cmd {
 		}
 
 		return conversationLoadedMsg{messages: messages}
+	}
+}
+
+func (m Model) openSourceRepo() tea.Cmd {
+	return func() tea.Msg {
+		_, err := data.RunGH("repo", "view", "maxbeizer/gh-agent-viz", "--web")
+		if err != nil {
+			return errMsg{fmt.Errorf("failed to open repo: %w", err)}
+		}
+		return nil
+	}
+}
+
+func (m Model) openFileIssue() tea.Cmd {
+	return func() tea.Msg {
+		_, err := data.RunGH("issue", "create", "-R", "maxbeizer/gh-agent-viz", "--web")
+		if err != nil {
+			return errMsg{fmt.Errorf("failed to open issue form: %w", err)}
+		}
+		return nil
 	}
 }
 


### PR DESCRIPTION
Adds two meta shortcuts:
- `!` opens the gh-agent-viz repo in browser
- `@` opens the new issue form in browser

Both shown in the `?` help overlay under a Meta section.

Closes #148