### PR TITLE
feat: overhaul mission control into summary dashboard

### DIFF
--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -706,18 +706,6 @@ func (m Model) handleMissionKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.mission.MoveCursor(1)
 	case "k", "up":
 		m.mission.MoveCursor(-1)
-	case "enter":
-		session := m.mission.SelectedSession()
-		if session != nil {
-			if session.Source == data.SourceLocalCopilot {
-				m.ctx.Error = nil
-				m.viewMode = ViewModeDetail
-				m.taskDetail.SetTask(session)
-				return m, nil
-			}
-			m.viewMode = ViewModeDetail
-			return m, m.fetchTaskDetail(session.ID, session.Repository)
-		}
 	case "r":
 		return m, m.fetchTasks
 	}


### PR DESCRIPTION
Complete rewrite of mission control (`M` key). Was a redundant card list — now a proper summary dashboard:

```
  ● 3 in progress    💤 2 idle    🧑 1 waiting on you    ✅ 12 done
  ████████████████   ████████     ████                    ░░░░░░░░░░░░░░░░░░░

  Repos
  ─────
  owner/api          ● 2 active   💤 1 idle   ✅ 4 done
  owner/frontend     ● 1 active               ✅ 3 done

  Needs your attention
  ─────
  🧑 "Should I refactor the auth module?"     owner/api     5m ago
```

Navigate repos with j/k, esc to return to list.