### PR TITLE
fix: PR lookup includes merged PRs, cleaner toast design

### DIFF
--- a/internal/data/agentapi.go
+++ b/internal/data/agentapi.go
@@ -226,13 +226,19 @@ func RunGH(args ...string) ([]byte, error) {
 	return runGH(args...)
 }
 
-// FetchPRForBranch looks up an open PR for the given repo and branch.
+// FetchPRForBranch looks up a PR (open or merged) for the given repo and branch.
 // Returns (prNumber, prURL, err). If no PR is found, returns (0, "", nil).
+// Skips default branches (main, master) since they don't have PRs.
 func FetchPRForBranch(repo, branch string) (int, string, error) {
 	if repo == "" || branch == "" {
 		return 0, "", nil
 	}
-	output, err := runGH("pr", "list", "-R", repo, "--head", branch, "--json", "number,url", "--limit", "1")
+	// Default branches won't have PRs
+	b := strings.ToLower(strings.TrimSpace(branch))
+	if b == "main" || b == "master" {
+		return 0, "", nil
+	}
+	output, err := runGH("pr", "list", "-R", repo, "--head", branch, "--state", "all", "--json", "number,url", "--limit", "1")
 	if err != nil {
 		return 0, "", nil // silently fail — PR lookup is best-effort
 	}

--- a/internal/tui/components/toast/toast.go
+++ b/internal/tui/components/toast/toast.go
@@ -70,28 +70,30 @@ func (m *Model) Tick() {
 	m.toasts = alive
 }
 
-// View renders the toast stack as a right-aligned overlay block.
+// View renders the toast stack as minimal single-line notifications.
 // Returns empty string when no active toasts.
 func (m Model) View() string {
 	if len(m.toasts) == 0 {
 		return ""
 	}
 
-	border := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.AdaptiveColor{Light: "244", Dark: "238"}).
-		Padding(0, 1).
-		Width(m.width)
+	style := lipgloss.NewStyle().
+		PaddingLeft(1).
+		PaddingRight(1)
 
-	var blocks []string
+	titleStyle := lipgloss.NewStyle().Bold(true)
+	msgStyle := lipgloss.NewStyle().Faint(true)
+
+	var lines []string
 	for _, t := range m.toasts {
-		line1 := fmt.Sprintf("%s \"%s\"", t.Icon, t.Title)
-		line2 := fmt.Sprintf("   %s", t.Message)
-		block := border.Render(line1 + "\n" + line2)
-		blocks = append(blocks, block)
+		line := fmt.Sprintf("%s %s %s",
+			t.Icon,
+			titleStyle.Render(t.Title),
+			msgStyle.Render(t.Message))
+		lines = append(lines, style.Render(line))
 	}
 
-	return strings.Join(blocks, "\n")
+	return strings.Join(lines, "\n")
 }
 
 // HasToasts returns true if there are active toasts to display.

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -360,14 +360,9 @@ func (m Model) View() string {
 		result = m.help.View()
 	}
 
-	// Overlay toasts in the top-right corner
+	// Show toasts inline below header
 	if m.toast.HasToasts() {
-		toastWidth := m.ctx.Width / 3
-		if toastWidth < 30 {
-			toastWidth = 30
-		}
-		m.toast.SetWidth(toastWidth)
-		toastView := lipgloss.PlaceHorizontal(m.ctx.Width, lipgloss.Right, m.toast.View())
+		toastView := m.toast.View()
 		result = toastView + "\n" + result
 	}
 
@@ -993,7 +988,7 @@ func (m Model) openTaskPR(session *data.Session) tea.Cmd {
 			}
 		}
 
-		return errMsg{fmt.Errorf("no pull request found for this session")}
+		return errMsg{fmt.Errorf("no PR found for this branch")}
 	}
 }
 
@@ -1251,7 +1246,7 @@ func (m Model) fetchPRDiff(session *data.Session) tea.Cmd {
 			}
 		}
 		if prNumber == 0 {
-			return errMsg{fmt.Errorf("no pull request found for this session")}
+			return errMsg{fmt.Errorf("no PR found for this branch")}
 		}
 		raw, err := data.FetchPRDiff(prNumber, repo)
 		if err != nil {


### PR DESCRIPTION
Three fixes:

**PR lookup**: Now uses `--state all` to find merged/closed PRs (not just open). Skips main/master branches since they don't have PRs. Better error message.

**Toast design**: Redesigned from heavy bordered boxes to minimal single-line notifications: `● Session Name running → completed`. No border, just bold title + faint message.