### PR TITLE
fix: diff loading state and PR branch indicator

### DIFF
--- a/internal/tui/components/diffview/diffview.go
+++ b/internal/tui/components/diffview/diffview.go
@@ -24,6 +24,7 @@ type Model struct {
 	width    int
 	height   int
 	ready    bool
+	loading  bool
 }
 
 // Styles for diff rendering
@@ -48,9 +49,16 @@ func New(width, height int) Model {
 // SetDiffs updates the file diffs and re-renders the viewport content
 func (m *Model) SetDiffs(files []FileDiff) {
 	m.files = files
+	m.loading = false
 	m.viewport.SetContent(m.renderDiffs())
 	m.viewport.GotoTop()
 	m.ready = true
+}
+
+// SetLoading puts the diff view in a loading state
+func (m *Model) SetLoading() {
+	m.loading = true
+	m.ready = false
 }
 
 // SetSize updates the viewport dimensions
@@ -66,8 +74,11 @@ func (m *Model) SetSize(width, height int) {
 
 // View renders the diff view
 func (m Model) View() string {
+	if m.loading {
+		return lipgloss.NewStyle().Padding(1, 2).Render("🔄 Loading diff...")
+	}
 	if !m.ready || len(m.files) == 0 {
-		return "No diffs available"
+		return lipgloss.NewStyle().Padding(1, 2).Render("No diffs available")
 	}
 	return m.viewport.View()
 }

--- a/internal/tui/components/diffview/diffview_test.go
+++ b/internal/tui/components/diffview/diffview_test.go
@@ -131,7 +131,7 @@ func TestRenderFileHeader(t *testing.T) {
 func TestModel_EmptyState(t *testing.T) {
 	m := New(80, 24)
 	view := m.View()
-	if view != "No diffs available" {
+	if !strings.Contains(view, "No diffs available") {
 		t.Errorf("expected empty state message, got %q", view)
 	}
 }

--- a/internal/tui/components/tasklist/tasklist.go
+++ b/internal/tui/components/tasklist/tasklist.go
@@ -214,6 +214,12 @@ func (m Model) renderRow(sessionIdx int, session data.Session, selected bool, wi
 	// Meta line: repo + time, dimmed for visual hierarchy
 	repo := truncate(rowRepository(session), width/2)
 	metaText := fmt.Sprintf("    %s  %s", repo, formatTime(session.UpdatedAt))
+
+	// Show PR indicator for sessions with feature branches
+	if hasPRBranch(session) {
+		metaText += "  🔀"
+	}
+
 	if dur := compactDuration(session); dur != "" {
 		durStr := "⏱ " + dur
 		pad := width - len(metaText) - len(durStr)
@@ -621,6 +627,15 @@ func sessionHasLinkedPR(session data.Session) bool {
 		return true
 	}
 	return session.PRNumber > 0 && strings.TrimSpace(session.Repository) != ""
+}
+
+// hasPRBranch returns true if the session is on a feature branch (not main/master)
+func hasPRBranch(session data.Session) bool {
+	branch := strings.ToLower(strings.TrimSpace(session.Branch))
+	if branch == "" || branch == "main" || branch == "master" {
+		return false
+	}
+	return strings.TrimSpace(session.Repository) != ""
 }
 
 // SetSize updates the available rendering size for responsive layout.

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -496,6 +496,7 @@ return m, m.fetchConversation(session.ID)
 	case "d":
 		session := m.taskList.SelectedTask()
 		if session != nil && canShowDiff(session) {
+			m.diffView.SetLoading()
 			m.viewMode = ViewModeDiff
 			return m, m.fetchPRDiff(session)
 		} else if session != nil {
@@ -555,6 +556,7 @@ return m, m.fetchConversation(session.ID)
 	case "d":
 		session := m.taskList.SelectedTask()
 		if session != nil && canShowDiff(session) {
+			m.diffView.SetLoading()
 			m.viewMode = ViewModeDiff
 			return m, m.fetchPRDiff(session)
 		}


### PR DESCRIPTION
Two improvements:

- **Diff loading**: Shows `🔄 Loading diff...` while fetching instead of briefly flashing "No diffs available"
- **PR indicator**: Sessions on feature branches show a `🔀` in the meta line so you can easily see which sessions have PRs/diffs available (press `d` or `o` on those)