### PR TITLE
fix: diff esc returns to list, cleaner PR indicator

### DIFF
--- a/internal/tui/components/tasklist/tasklist.go
+++ b/internal/tui/components/tasklist/tasklist.go
@@ -215,11 +215,6 @@ func (m Model) renderRow(sessionIdx int, session data.Session, selected bool, wi
 	repo := truncate(rowRepository(session), width/2)
 	metaText := fmt.Sprintf("    %s  %s", repo, formatTime(session.UpdatedAt))
 
-	// Show PR indicator for sessions with feature branches
-	if hasPRBranch(session) {
-		metaText += "  🔀"
-	}
-
 	if dur := compactDuration(session); dur != "" {
 		durStr := "⏱ " + dur
 		pad := width - len(metaText) - len(durStr)
@@ -595,7 +590,11 @@ func rowRepository(session data.Session) string {
 	if branch == "" {
 		return repository
 	}
-	return fmt.Sprintf("%s @ %s", repository, branch)
+	base := fmt.Sprintf("%s @ %s", repository, branch)
+	if hasPRBranch(session) {
+		return base + " · PR"
+	}
+	return base
 }
 
 // compactDuration returns a short duration string for the metadata line.

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -568,7 +568,7 @@ return m, m.fetchConversation(session.ID)
 func (m Model) handleDiffKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
-		m.viewMode = ViewModeDetail
+		m.viewMode = ViewModeList
 		return m, nil
 	}
 


### PR DESCRIPTION
Two fixes:

- **Diff esc**: Returns to list view instead of detail view (which caused 'no session selected' when coming from list)
- **PR indicator**: Changed from standalone `🔀` emoji to inline `· PR` text appended to the branch name: `owner/repo @ feature-branch · PR`