### PR TITLE
feat: show Copilot token usage per session

### DIFF
--- a/internal/data/session.go
+++ b/internal/data/session.go
@@ -26,6 +26,12 @@ type SessionTelemetry struct {
 	ConversationTurns int           // number of conversation exchanges
 	UserMessages      int           // messages from user
 	AssistantMessages int           // messages from assistant
+	// Token usage from CLI logs
+	Model        string // last model used
+	InputTokens  int64  // total prompt tokens
+	OutputTokens int64  // total completion tokens
+	CachedTokens int64  // total cached prompt tokens
+	ModelCalls   int    // number of model API calls
 }
 
 // Session represents a unified model for both agent-task and local Copilot sessions

--- a/internal/data/tokenusage.go
+++ b/internal/data/tokenusage.go
@@ -1,0 +1,149 @@
+package data
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// TokenUsage holds aggregated token usage for a single session.
+type TokenUsage struct {
+	SessionID    string
+	Model        string
+	InputTokens  int64
+	OutputTokens int64
+	CachedTokens int64
+	Calls        int
+}
+
+// responseUsage mirrors the JSON usage block in log output.
+type responseUsage struct {
+	CompletionTokens int64 `json:"completion_tokens"`
+	PromptTokens     int64 `json:"prompt_tokens"`
+	PromptDetails    struct {
+		CachedTokens int64 `json:"cached_tokens"`
+	} `json:"prompt_tokens_details"`
+	TotalTokens int64 `json:"total_tokens"`
+}
+
+// responseBlock mirrors the JSON response block containing model and usage.
+type responseBlock struct {
+	Model string        `json:"model"`
+	Usage responseUsage `json:"usage"`
+}
+
+var sessionFlushRe = regexp.MustCompile(`Flushed \d+ events to session ([0-9a-fA-F-]{36})`)
+
+// FetchTokenUsage parses recent Copilot CLI log files and returns per-session
+// token usage. Only files modified in the last 7 days are parsed.
+func FetchTokenUsage() (map[string]*TokenUsage, error) {
+	return fetchTokenUsageFromDir(defaultLogDir())
+}
+
+func defaultLogDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".copilot", "logs")
+}
+
+func fetchTokenUsageFromDir(logDir string) (map[string]*TokenUsage, error) {
+	if logDir == "" {
+		return map[string]*TokenUsage{}, nil
+	}
+
+	files, err := filepath.Glob(filepath.Join(logDir, "process-*.log"))
+	if err != nil {
+		return map[string]*TokenUsage{}, nil
+	}
+
+	cutoff := time.Now().Add(-7 * 24 * time.Hour)
+	result := map[string]*TokenUsage{}
+
+	for _, f := range files {
+		info, err := os.Stat(f)
+		if err != nil || info.ModTime().Before(cutoff) {
+			continue
+		}
+		parseLogFile(f, result)
+	}
+
+	return result, nil
+}
+
+func parseLogFile(path string, result map[string]*TokenUsage) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 512*1024), 2*1024*1024)
+
+	var currentSession string
+	var inResponse bool
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Track session ID from flush lines
+		if matches := sessionFlushRe.FindStringSubmatch(line); len(matches) == 2 {
+			currentSession = matches[1]
+			continue
+		}
+
+		// Detect start of response block
+		if strings.Contains(line, "[DEBUG] response (Request-ID") {
+			inResponse = true
+			continue
+		}
+
+		// Look for JSON data lines inside response blocks
+		if inResponse && strings.Contains(line, "[DEBUG] {") {
+			jsonStr := extractJSON(line)
+			if jsonStr != "" {
+				var block responseBlock
+				if err := json.Unmarshal([]byte(jsonStr), &block); err == nil && block.Usage.TotalTokens > 0 {
+					sid := currentSession
+					if sid == "" {
+						sid = "_unknown"
+					}
+					usage, ok := result[sid]
+					if !ok {
+						usage = &TokenUsage{SessionID: sid}
+						result[sid] = usage
+					}
+					usage.InputTokens += block.Usage.PromptTokens
+					usage.OutputTokens += block.Usage.CompletionTokens
+					usage.CachedTokens += block.Usage.PromptDetails.CachedTokens
+					usage.Calls++
+					if block.Model != "" {
+						usage.Model = block.Model
+					}
+				}
+			}
+			inResponse = false
+			continue
+		}
+
+		// Reset response tracking on non-data lines after response header
+		if inResponse && !strings.Contains(line, "[DEBUG] data:") {
+			inResponse = false
+		}
+	}
+}
+
+// extractJSON pulls a JSON object from a log line like `[DEBUG] { ... }`
+func extractJSON(line string) string {
+	idx := strings.Index(line, "{")
+	if idx < 0 {
+		return ""
+	}
+	return line[idx:]
+}

--- a/internal/data/tokenusage_test.go
+++ b/internal/data/tokenusage_test.go
@@ -1,0 +1,121 @@
+package data
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const sampleLog = `2025-01-15 10:00:00 [INFO] Starting session
+2025-01-15 10:00:01 [INFO] Flushed 5 events to session abc12345-1234-1234-1234-abcdef123456
+2025-01-15 10:00:02 [DEBUG] response (Request-ID: req-123)
+2025-01-15 10:00:02 [DEBUG] data: {"id":"chatcmpl-1"}
+2025-01-15 10:00:02 [DEBUG] {"model":"claude-opus-4.5","usage":{"completion_tokens":100,"prompt_tokens":5000,"prompt_tokens_details":{"cached_tokens":3000},"total_tokens":5100}}
+2025-01-15 10:00:10 [DEBUG] response (Request-ID: req-456)
+2025-01-15 10:00:10 [DEBUG] data: {"id":"chatcmpl-2"}
+2025-01-15 10:00:10 [DEBUG] {"model":"claude-opus-4.5","usage":{"completion_tokens":200,"prompt_tokens":8000,"prompt_tokens_details":{"cached_tokens":6000},"total_tokens":8200}}
+2025-01-15 10:01:00 [INFO] Flushed 3 events to session def67890-5678-5678-5678-abcdef567890
+2025-01-15 10:01:02 [DEBUG] response (Request-ID: req-789)
+2025-01-15 10:01:02 [DEBUG] data: {"id":"chatcmpl-3"}
+2025-01-15 10:01:02 [DEBUG] {"model":"gpt-4.1","usage":{"completion_tokens":50,"prompt_tokens":2000,"prompt_tokens_details":{"cached_tokens":1000},"total_tokens":2050}}
+`
+
+func TestParseLogFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "process-test.log")
+	if err := os.WriteFile(path, []byte(sampleLog), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := map[string]*TokenUsage{}
+	parseLogFile(path, result)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 sessions, got %d", len(result))
+	}
+
+	s1 := result["abc12345-1234-1234-1234-abcdef123456"]
+	if s1 == nil {
+		t.Fatal("session abc not found")
+	}
+	if s1.InputTokens != 13000 {
+		t.Errorf("expected input 13000, got %d", s1.InputTokens)
+	}
+	if s1.OutputTokens != 300 {
+		t.Errorf("expected output 300, got %d", s1.OutputTokens)
+	}
+	if s1.CachedTokens != 9000 {
+		t.Errorf("expected cached 9000, got %d", s1.CachedTokens)
+	}
+	if s1.Calls != 2 {
+		t.Errorf("expected 2 calls, got %d", s1.Calls)
+	}
+	if s1.Model != "claude-opus-4.5" {
+		t.Errorf("expected model claude-opus-4.5, got %s", s1.Model)
+	}
+
+	s2 := result["def67890-5678-5678-5678-abcdef567890"]
+	if s2 == nil {
+		t.Fatal("session def not found")
+	}
+	if s2.InputTokens != 2000 {
+		t.Errorf("expected input 2000, got %d", s2.InputTokens)
+	}
+	if s2.Calls != 1 {
+		t.Errorf("expected 1 call, got %d", s2.Calls)
+	}
+	if s2.Model != "gpt-4.1" {
+		t.Errorf("expected model gpt-4.1, got %s", s2.Model)
+	}
+}
+
+func TestFetchTokenUsageEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	result, err := fetchTokenUsageFromDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got %d", len(result))
+	}
+}
+
+func TestFetchTokenUsageMissingDir(t *testing.T) {
+	result, err := fetchTokenUsageFromDir("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got %d", len(result))
+	}
+}
+
+func TestMalformedLinesSkipped(t *testing.T) {
+	dir := t.TempDir()
+	content := `2025-01-15 10:00:01 [INFO] Flushed 5 events to session abc12345-1234-1234-1234-abcdef123456
+2025-01-15 10:00:02 [DEBUG] response (Request-ID: req-123)
+2025-01-15 10:00:02 [DEBUG] data: {"id":"chatcmpl-1"}
+2025-01-15 10:00:02 [DEBUG] {not valid json at all!!!
+2025-01-15 10:00:03 [DEBUG] response (Request-ID: req-456)
+2025-01-15 10:00:03 [DEBUG] data: {"id":"chatcmpl-2"}
+2025-01-15 10:00:03 [DEBUG] {"model":"claude-opus-4.5","usage":{"completion_tokens":50,"prompt_tokens":1000,"prompt_tokens_details":{"cached_tokens":500},"total_tokens":1050}}
+`
+	path := filepath.Join(dir, "process-test.log")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := map[string]*TokenUsage{}
+	parseLogFile(path, result)
+
+	s := result["abc12345-1234-1234-1234-abcdef123456"]
+	if s == nil {
+		t.Fatal("session not found")
+	}
+	if s.Calls != 1 {
+		t.Errorf("expected 1 valid call, got %d", s.Calls)
+	}
+	if s.InputTokens != 1000 {
+		t.Errorf("expected input 1000, got %d", s.InputTokens)
+	}
+}

--- a/internal/tui/components/mission/mission.go
+++ b/internal/tui/components/mission/mission.go
@@ -278,6 +278,16 @@ if barWidth > 0 && m.stats.Total > 0 {
 bar := m.renderBar(barWidth)
 lines = append(lines, "  "+bar)
 }
+// Total token usage across all sessions
+totalTokens := int64(0)
+for _, s := range m.sessions {
+if s.Telemetry != nil {
+totalTokens += s.Telemetry.InputTokens
+}
+}
+if totalTokens > 0 {
+lines = append(lines, fmt.Sprintf("  🪙 %s tokens consumed", formatTokenCount(totalTokens)))
+}
 lines = append(lines, "")
 
 // ── Repos with activity ──
@@ -465,4 +475,14 @@ return "● Working..."
 default:
 return "● Working..."
 }
+}
+
+func formatTokenCount(n int64) string {
+if n >= 1_000_000 {
+return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
+}
+if n >= 1_000 {
+return fmt.Sprintf("%.1fK", float64(n)/1_000)
+}
+return fmt.Sprintf("%d", n)
 }

--- a/internal/tui/components/taskdetail/taskdetail.go
+++ b/internal/tui/components/taskdetail/taskdetail.go
@@ -84,6 +84,17 @@ func (m Model) View() string {
 		if t.ConversationTurns == 0 && t.Duration == 0 {
 			details = append(details, "No usage data available for this session")
 		}
+		if t.InputTokens > 0 {
+			details = append(details,
+				fmt.Sprintf("🪙 Tokens: %s in, %s out, %s cached (%d calls)",
+					formatTokenCount(t.InputTokens),
+					formatTokenCount(t.OutputTokens),
+					formatTokenCount(t.CachedTokens),
+					t.ModelCalls))
+			if t.Model != "" {
+				details = append(details, fmt.Sprintf("🤖 Model: %s", t.Model))
+			}
+		}
 	}
 
 	// Show dependency graph if relationships exist
@@ -183,6 +194,17 @@ func (m Model) ViewSplit() string {
 		}
 		if t.ConversationTurns == 0 && t.Duration == 0 {
 			details = append(details, "No usage data available")
+		}
+		if t.InputTokens > 0 {
+			details = append(details,
+				fmt.Sprintf("🪙 Tokens: %s in, %s out, %s cached (%d calls)",
+					formatTokenCount(t.InputTokens),
+					formatTokenCount(t.OutputTokens),
+					formatTokenCount(t.CachedTokens),
+					t.ModelCalls))
+			if t.Model != "" {
+				details = append(details, fmt.Sprintf("🤖 Model: %s", t.Model))
+			}
 		}
 	}
 
@@ -298,4 +320,14 @@ func timelineWidth(availableWidth int) int {
 		return 48
 	}
 	return w
+}
+
+func formatTokenCount(n int64) string {
+	if n >= 1_000_000 {
+		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
+	}
+	if n >= 1_000 {
+		return fmt.Sprintf("%.1fK", float64(n)/1_000)
+	}
+	return fmt.Sprintf("%d", n)
 }

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -792,6 +792,21 @@ func (m Model) fetchTasks() tea.Msg {
 	}
 	sessions = visible
 
+	// Enrich sessions with token usage from CLI logs
+	tokenUsage, _ := data.FetchTokenUsage()
+	for i := range sessions {
+		if usage, ok := tokenUsage[sessions[i].ID]; ok {
+			if sessions[i].Telemetry == nil {
+				sessions[i].Telemetry = &data.SessionTelemetry{}
+			}
+			sessions[i].Telemetry.Model = usage.Model
+			sessions[i].Telemetry.InputTokens = usage.InputTokens
+			sessions[i].Telemetry.OutputTokens = usage.OutputTokens
+			sessions[i].Telemetry.CachedTokens = usage.CachedTokens
+			sessions[i].Telemetry.ModelCalls = usage.Calls
+		}
+	}
+
 	// Compute counts across all visible (non-dismissed) sessions
 	counts := FilterCounts{All: len(sessions)}
 	for _, session := range sessions {


### PR DESCRIPTION
## Summary

Parses `~/.copilot/logs/process-*.log` to extract per-session token usage (input/output/cached tokens, model name, call count) and displays it in the TUI.

### Changes

- **`internal/data/tokenusage.go`**: Log parser that scans recent Copilot CLI log files (last 7 days) for session IDs and model response JSON blocks, aggregating token counts per session.
- **`internal/data/tokenusage_test.go`**: Tests for parsing known log content, empty/missing dirs, and malformed line tolerance.
- **`internal/data/session.go`**: Extended `SessionTelemetry` with `Model`, `InputTokens`, `OutputTokens`, `CachedTokens`, `ModelCalls` fields.
- **`internal/tui/ui.go`**: Wired `FetchTokenUsage()` into `fetchTasks()` to enrich sessions at load time.
- **`internal/tui/components/taskdetail/taskdetail.go`**: Shows token stats (🪙) and model (🤖) in the Session Stats section of both View and ViewSplit.
- **`internal/tui/components/mission/mission.go`**: Shows total tokens consumed in the fleet summary bar.

### Design

- Defensive parsing: malformed lines are skipped, missing logs return empty maps
- Performance: only parses files modified in the last 7 days
- Uses large bufio.Scanner buffer (2MB) for long log lines

Inspired by https://github.com/srt32/copilot-token-usage

Closes #163