### PR TITLE
fix: token parser, colored status icons, mission enter

### DIFF
--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -390,13 +390,13 @@ func newSolarizedLightTheme() *Theme {
 	}
 }
 
-// StatusIcon returns the appropriate emoji icon for a given status
+// StatusIcon returns the appropriate icon for a given status, with color.
 func StatusIcon(status string) string {
 	switch status {
 	case "running":
-		return "●"
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("42")).Render("●")
 	case "queued":
-		return "○"
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("222")).Render("○")
 	case "needs-input":
 		return "🧑"
 	case "completed":

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -708,6 +708,9 @@ func (m Model) handleMissionKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.mission.MoveCursor(1)
 	case "k", "up":
 		m.mission.MoveCursor(-1)
+	case "enter":
+		// Return to list view (enter feels natural to "drill in")
+		m.viewMode = ViewModeList
 	case "r":
 		return m, m.fetchTasks
 	}


### PR DESCRIPTION
Three fixes:

- **Token parser**: Now handles multi-line JSON (log continuation lines have no `[DEBUG]` prefix). Strips `capi:` model prefixes. Successfully parses 180+ sessions.
- **Status icons**: `●` and `○` now rendered with green/amber color in detail view (was plain gray)
- **Mission control**: `enter` returns to list view