### PR TITLE
refactor: consolidate duplicated helpers into data package

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -89,6 +89,15 @@ docs/
 - If a REST API appears in the future, switch to using `go-gh` REST client (`gh.DefaultRESTClient()`) directly
 - Changes that affect data handling, telemetry, or external integrations must update `docs/SECURITY.md`
 
+## Shared Helpers (internal/data/session.go)
+
+When working with session data across components, use these shared functions instead of reimplementing:
+- `data.SessionNeedsAttention(s)` — true for needs-input/failed only
+- `data.SessionIsActiveNotIdle(s)` — true for active sessions updated within 20min
+- `data.StatusIsActive(status)` — true for running/queued/active/open/in-progress
+- `data.IsDefaultBranch(branch)` — true for main/master/empty
+- `data.FormatTokenCount(n)` — "2.7M", "11.7K", "437"
+
 ## Testing
 
 - When writing tests, use Go's standard `testing` package

--- a/internal/data/agentapi.go
+++ b/internal/data/agentapi.go
@@ -234,8 +234,7 @@ func FetchPRForBranch(repo, branch string) (int, string, error) {
 		return 0, "", nil
 	}
 	// Default branches won't have PRs
-	b := strings.ToLower(strings.TrimSpace(branch))
-	if b == "main" || b == "master" {
+	if IsDefaultBranch(branch) {
 		return 0, "", nil
 	}
 	output, err := runGH("pr", "list", "-R", repo, "--head", branch, "--state", "all", "--json", "number,url", "--limit", "1")

--- a/internal/tui/components/kanban/kanban.go
+++ b/internal/tui/components/kanban/kanban.go
@@ -51,19 +51,6 @@ func statusBelongsToColumn(session data.Session, colStatus string) bool {
 	return false
 }
 
-// isActiveNotIdle returns true for sessions actively working (not idle 20+ min)
-func isActiveNotIdle(session data.Session) bool {
-	s := strings.ToLower(strings.TrimSpace(session.Status))
-	isActive := s == "running" || s == "active" || s == "queued" || s == "needs-input"
-	if !isActive {
-		return false
-	}
-	if session.UpdatedAt.IsZero() {
-		return true
-	}
-	return time.Since(session.UpdatedAt) < data.AttentionStaleThreshold
-}
-
 // Model represents the kanban board state
 type Model struct {
 	columns           []Column
@@ -297,7 +284,7 @@ func (m *Model) renderColumn(col Column, colIdx, width, cardAreaHeight int, focu
 // renderCard renders a single session card.
 func (m *Model) renderCard(session data.Session, width int, selected bool) string {
 	icon := m.statusIcon(session.Status)
-	if m.animStatusIcon != nil && isActiveNotIdle(session) {
+	if m.animStatusIcon != nil && data.SessionIsActiveNotIdle(session) {
 		icon = m.animStatusIcon(session.Status, m.animFrame)
 	}
 

--- a/internal/tui/components/taskdetail/depgraph.go
+++ b/internal/tui/components/taskdetail/depgraph.go
@@ -147,7 +147,7 @@ func sessionLabel(s *data.Session) string {
 // e.g., "feature/auth-bug" → "feature/auth", "fix/login-flow" → "fix/login"
 func branchGroupPrefix(branch string) string {
 	branch = strings.TrimSpace(branch)
-	if branch == "" || branch == "main" || branch == "master" {
+	if data.IsDefaultBranch(branch) {
 		return ""
 	}
 

--- a/internal/tui/components/taskdetail/taskdetail.go
+++ b/internal/tui/components/taskdetail/taskdetail.go
@@ -87,9 +87,9 @@ func (m Model) View() string {
 		if t.InputTokens > 0 {
 			details = append(details,
 				fmt.Sprintf("🪙 Tokens: %s in, %s out, %s cached (%d calls)",
-					formatTokenCount(t.InputTokens),
-					formatTokenCount(t.OutputTokens),
-					formatTokenCount(t.CachedTokens),
+					data.FormatTokenCount(t.InputTokens),
+					data.FormatTokenCount(t.OutputTokens),
+					data.FormatTokenCount(t.CachedTokens),
 					t.ModelCalls))
 			if t.Model != "" {
 				details = append(details, fmt.Sprintf("🤖 Model: %s", t.Model))
@@ -198,9 +198,9 @@ func (m Model) ViewSplit() string {
 		if t.InputTokens > 0 {
 			details = append(details,
 				fmt.Sprintf("🪙 Tokens: %s in, %s out, %s cached (%d calls)",
-					formatTokenCount(t.InputTokens),
-					formatTokenCount(t.OutputTokens),
-					formatTokenCount(t.CachedTokens),
+					data.FormatTokenCount(t.InputTokens),
+					data.FormatTokenCount(t.OutputTokens),
+					data.FormatTokenCount(t.CachedTokens),
 					t.ModelCalls))
 			if t.Model != "" {
 				details = append(details, fmt.Sprintf("🤖 Model: %s", t.Model))
@@ -322,12 +322,3 @@ func timelineWidth(availableWidth int) int {
 	return w
 }
 
-func formatTokenCount(n int64) string {
-	if n >= 1_000_000 {
-		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
-	}
-	if n >= 1_000 {
-		return fmt.Sprintf("%.1fK", float64(n)/1_000)
-	}
-	return fmt.Sprintf("%d", n)
-}

--- a/internal/tui/components/tasklist/tasklist.go
+++ b/internal/tui/components/tasklist/tasklist.go
@@ -173,7 +173,7 @@ func (m Model) renderRow(sessionIdx int, session data.Session, selected bool, wi
 
 	// Only animate icon for sessions that are actively working (not idle)
 	icon := m.statusIcon(session.Status)
-	if m.animStatusIcon != nil && isActiveNotIdle(session) {
+	if m.animStatusIcon != nil && data.SessionIsActiveNotIdle(session) {
 		icon = m.animStatusIcon(session.Status, m.animFrame)
 	}
 
@@ -456,17 +456,6 @@ func isActiveStatus(status string) bool {
 	return data.StatusIsActive(status) || strings.EqualFold(strings.TrimSpace(status), "needs-input")
 }
 
-// isActiveNotIdle returns true for sessions that are actively working (not idle 20+ min)
-func isActiveNotIdle(session data.Session) bool {
-	if !isActiveStatus(session.Status) {
-		return false
-	}
-	if session.UpdatedAt.IsZero() {
-		return true
-	}
-	return time.Since(session.UpdatedAt) < data.AttentionStaleThreshold
-}
-
 func sessionBadge(session data.Session, duplicateCount int) string {
 	if strings.EqualFold(strings.TrimSpace(session.Status), "needs-input") {
 		badge := "🧑 waiting on you"
@@ -636,8 +625,7 @@ func sessionHasLinkedPR(session data.Session) bool {
 
 // hasPRBranch returns true if the session is on a feature branch (not main/master)
 func hasPRBranch(session data.Session) bool {
-	branch := strings.ToLower(strings.TrimSpace(session.Branch))
-	if branch == "" || branch == "main" || branch == "master" {
+	if data.IsDefaultBranch(session.Branch) {
 		return false
 	}
 	return strings.TrimSpace(session.Repository) != ""

--- a/internal/tui/components/tasklist/tasklist_test.go
+++ b/internal/tui/components/tasklist/tasklist_test.go
@@ -768,21 +768,21 @@ func TestHasPRBranch_EmptyRepo(t *testing.T) {
 
 func TestIsActiveNotIdle_RecentlyUpdatedRunning(t *testing.T) {
 	s := data.Session{Status: "running", UpdatedAt: time.Now().Add(-2 * time.Minute)}
-	if !isActiveNotIdle(s) {
+	if !data.SessionIsActiveNotIdle(s) {
 		t.Fatal("expected isActiveNotIdle true for recently updated running session")
 	}
 }
 
 func TestIsActiveNotIdle_IdleThirtyMinutes(t *testing.T) {
 	s := data.Session{Status: "running", UpdatedAt: time.Now().Add(-30 * time.Minute)}
-	if isActiveNotIdle(s) {
+	if data.SessionIsActiveNotIdle(s) {
 		t.Fatal("expected isActiveNotIdle false for session idle 30+ minutes")
 	}
 }
 
 func TestIsActiveNotIdle_CompletedSession(t *testing.T) {
 	s := data.Session{Status: "completed", UpdatedAt: time.Now()}
-	if isActiveNotIdle(s) {
+	if data.SessionIsActiveNotIdle(s) {
 		t.Fatal("expected isActiveNotIdle false for completed session")
 	}
 }


### PR DESCRIPTION
Moves duplicated helper functions into `internal/data/session.go` as shared exported functions:

- **`SessionIsActiveNotIdle`** — was duplicated in tasklist, kanban, and mission (3 copies)
- **`FormatTokenCount`** — was duplicated in taskdetail and mission (2 copies)
- **`IsDefaultBranch`** — was duplicated in agentapi, tasklist, and depgraph (3 copies)

Pure refactor — no behavior changes. All tests pass.

Also updates `.github/copilot-instructions.md` with a Shared Helpers section so future agents know to use these functions.