### PR TITLE
test: add stable regression tests for data, config, logview, taskdetail

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -104,3 +104,13 @@ When working with session data across components, use these shared functions ins
 - For TUI components, test the Model's Update function with specific messages and verify state changes
 - For the data layer, mock `exec.Command` output to test parsing without requiring `gh` to be installed
 - Add regression tests for parser hardening, malformed input handling, and error propagation paths
+
+## Testing Guidelines
+
+- Tests must be deterministic — no flaky tests
+- Avoid `time.Now()` or `time.Since()` in test assertions (use fixed timestamps)
+- Avoid filesystem access in unit tests (use temp dirs or mock data)
+- Pure function tests are preferred (input → output, no side effects)
+- Use `testing.T.TempDir()` when filesystem access is unavoidable
+- Mock `exec.Command` via the `execCommand` variable for CLI tests
+- Don't test Bubble Tea Update/View wiring directly — test component logic instead

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -207,3 +207,78 @@ func TestLoad_AnimationsFalse(t *testing.T) {
 		t.Error("expected animations disabled from config file")
 	}
 }
+
+func TestAsciiHeaderEnabled_DefaultTrue(t *testing.T) {
+	cfg := DefaultConfig()
+	if !cfg.AsciiHeaderEnabled() {
+		t.Error("expected ascii header enabled by default")
+	}
+}
+
+func TestAsciiHeaderEnabled_ExplicitTrue(t *testing.T) {
+	b := true
+	cfg := &Config{AsciiHeader: &b}
+	if !cfg.AsciiHeaderEnabled() {
+		t.Error("expected ascii header enabled when explicitly true")
+	}
+}
+
+func TestAsciiHeaderEnabled_ExplicitFalse(t *testing.T) {
+	b := false
+	cfg := &Config{AsciiHeader: &b}
+	if cfg.AsciiHeaderEnabled() {
+		t.Error("expected ascii header disabled when explicitly false")
+	}
+}
+
+func TestLoad_AsciiHeaderFalse(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "ascii-config.yml")
+
+	configContent := "asciiHeader: false\n"
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error loading config: %v", err)
+	}
+
+	if cfg.AsciiHeaderEnabled() {
+		t.Error("expected ascii header disabled from config file")
+	}
+}
+
+func TestLoad_ThemeField(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "theme-config.yml")
+
+	configContent := "theme: dark\n"
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error loading config: %v", err)
+	}
+
+	if cfg.Theme != "dark" {
+		t.Errorf("expected theme 'dark', got %q", cfg.Theme)
+	}
+}
+
+func TestDefaultConfig_FieldValues(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.Animations != nil {
+		t.Error("expected Animations to be nil by default")
+	}
+	if cfg.AsciiHeader != nil {
+		t.Error("expected AsciiHeader to be nil by default")
+	}
+	if cfg.Theme != "" {
+		t.Errorf("expected empty Theme by default, got %q", cfg.Theme)
+	}
+}

--- a/internal/data/session_test.go
+++ b/internal/data/session_test.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -73,5 +74,116 @@ func TestStatusIsActive_CaseInsensitive(t *testing.T) {
 		if !StatusIsActive(status) {
 			t.Fatalf("expected %q to be active", status)
 		}
+	}
+}
+
+func TestStatusIsActive_Inactive(t *testing.T) {
+	for _, status := range []string{"completed", "failed", "needs-input", "", "unknown"} {
+		if StatusIsActive(status) {
+			t.Fatalf("expected %q to NOT be active", status)
+		}
+	}
+}
+
+func TestIsDefaultBranch(t *testing.T) {
+	tests := []struct {
+		branch string
+		want   bool
+	}{
+		{"main", true},
+		{"master", true},
+		{"Main", true},
+		{"MASTER", true},
+		{"", true},
+		{"  main  ", true},
+		{"feature/foo", false},
+		{"develop", false},
+		{"main-backup", false},
+		{"my-master", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("branch=%q", tt.branch), func(t *testing.T) {
+			got := IsDefaultBranch(tt.branch)
+			if got != tt.want {
+				t.Errorf("IsDefaultBranch(%q) = %v, want %v", tt.branch, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatTokenCount(t *testing.T) {
+	tests := []struct {
+		n    int64
+		want string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{999, "999"},
+		{1000, "1.0K"},
+		{1500, "1.5K"},
+		{11700, "11.7K"},
+		{999999, "1000.0K"},
+		{1000000, "1.0M"},
+		{2700000, "2.7M"},
+		{10000000, "10.0M"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("n=%d", tt.n), func(t *testing.T) {
+			got := FormatTokenCount(tt.n)
+			if got != tt.want {
+				t.Errorf("FormatTokenCount(%d) = %q, want %q", tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFromAgentTask_ToAgentTask_Roundtrip(t *testing.T) {
+	original := AgentTask{
+		ID:         "roundtrip-123",
+		Status:     "running",
+		Title:      "Roundtrip Test",
+		Repository: "owner/repo",
+		Branch:     "feature/x",
+		PRURL:      "https://github.com/owner/repo/pull/42",
+		PRNumber:   42,
+		CreatedAt:  time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:  time.Date(2025, 6, 15, 11, 0, 0, 0, time.UTC),
+	}
+
+	session := FromAgentTask(original)
+	if session.Source != SourceAgentTask {
+		t.Errorf("expected source %q, got %q", SourceAgentTask, session.Source)
+	}
+
+	roundtripped := session.ToAgentTask()
+
+	if roundtripped.ID != original.ID {
+		t.Errorf("ID mismatch: %q != %q", roundtripped.ID, original.ID)
+	}
+	if roundtripped.Status != original.Status {
+		t.Errorf("Status mismatch: %q != %q", roundtripped.Status, original.Status)
+	}
+	if roundtripped.Title != original.Title {
+		t.Errorf("Title mismatch: %q != %q", roundtripped.Title, original.Title)
+	}
+	if roundtripped.Repository != original.Repository {
+		t.Errorf("Repository mismatch: %q != %q", roundtripped.Repository, original.Repository)
+	}
+	if roundtripped.Branch != original.Branch {
+		t.Errorf("Branch mismatch: %q != %q", roundtripped.Branch, original.Branch)
+	}
+	if roundtripped.PRURL != original.PRURL {
+		t.Errorf("PRURL mismatch: %q != %q", roundtripped.PRURL, original.PRURL)
+	}
+	if roundtripped.PRNumber != original.PRNumber {
+		t.Errorf("PRNumber mismatch: %d != %d", roundtripped.PRNumber, original.PRNumber)
+	}
+	if !roundtripped.CreatedAt.Equal(original.CreatedAt) {
+		t.Errorf("CreatedAt mismatch: %v != %v", roundtripped.CreatedAt, original.CreatedAt)
+	}
+	if !roundtripped.UpdatedAt.Equal(original.UpdatedAt) {
+		t.Errorf("UpdatedAt mismatch: %v != %v", roundtripped.UpdatedAt, original.UpdatedAt)
 	}
 }

--- a/internal/tui/components/logview/logview_test.go
+++ b/internal/tui/components/logview/logview_test.go
@@ -190,3 +190,36 @@ func TestView_NotLive_NoIndicator(t *testing.T) {
 		t.Errorf("expected no indicator for non-live session, got: %s", view)
 	}
 }
+
+func TestView_EmptyContent(t *testing.T) {
+	m := New(lipgloss.NewStyle(), 80, 24)
+	m.SetContent("")
+	view := m.View()
+	if !strings.Contains(view, "No logs available") {
+		t.Errorf("expected 'No logs available' for empty content, got: %s", view)
+	}
+}
+
+func TestNew_Defaults(t *testing.T) {
+	m := New(lipgloss.NewStyle(), 80, 24)
+	if m.ready {
+		t.Error("expected ready to be false on new model")
+	}
+	if m.followMode {
+		t.Error("expected followMode to be false on new model")
+	}
+	if m.liveSession {
+		t.Error("expected liveSession to be false on new model")
+	}
+	if m.rawContent != "" {
+		t.Error("expected rawContent to be empty on new model")
+	}
+}
+
+func TestLineCount_AfterSetContent(t *testing.T) {
+	m := New(lipgloss.NewStyle(), 80, 24)
+	m.SetContent("line1\nline2\nline3")
+	if m.lineCount < 1 {
+		t.Errorf("expected lineCount >= 1 after SetContent, got %d", m.lineCount)
+	}
+}


### PR DESCRIPTION
Adds deterministic tests for pure functions: IsDefaultBranch, FormatTokenCount, FromAgentTask/ToAgentTask roundtrip, DeriveLocalSessionStatus, parseAnyTime, parseSessionTime, needsHumanInput, isLocallyActiveStatus, formatEventTimestamp, processJSONBlock, formatDuration, detailValue, detailTitle, detailTimestamp, timelineWidth, sectionDivider, AsciiHeaderEnabled, and logview state management.

Updates `.github/copilot-instructions.md` with testing guidelines emphasizing deterministic, non-flaky tests.

**614 lines added across 7 files. All tests pass 3/3 runs.**

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>