### PR TITLE
fix: replace needs-input emoji for inclusivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An interactive terminal UI for visualizing GitHub Copilot coding agent sessions.
 - 📝 **Log Viewer** - Scrollable, searchable agent task logs
 - 💻 **Local Sessions** - Automatically ingests local Copilot CLI sessions from `~/.copilot/session-state/`
 - 🎨 **Status Indicators** - Color-coded status icons (running, queued, completed, failed)
-- 🧑 **Input Needed Detection** - Highlights sessions that appear blocked waiting for human input
+- ✋ **Input Needed Detection** - Highlights sessions that appear blocked waiting for human input
 - 🚦 **Action Reasons** - Every card includes an explicit `Needs your action:` reason (`waiting on your input`, `run failed`, `running but quiet`, or `no action needed`)
 - 🧭 **Action-First Ordering** - Sessions needing input/failure/quiet checks surface first, while older quiet duplicates are de-emphasized with a `↺ quiet duplicate` badge
 - ⚡ **Quick Actions** - Contextual hints only show actions available for the highlighted session

--- a/internal/tui/components/kanban/kanban_test.go
+++ b/internal/tui/components/kanban/kanban_test.go
@@ -16,7 +16,7 @@ func newTestModel() Model {
 		case "running":
 			return "🟢"
 		case "needs-input":
-			return "🧑"
+			return "✋"
 		case "completed":
 			return "✅"
 		case "failed":

--- a/internal/tui/components/mission/mission.go
+++ b/internal/tui/components/mission/mission.go
@@ -156,13 +156,13 @@ m.attention = nil
 for _, s := range m.sessions {
 status := strings.ToLower(strings.TrimSpace(s.Status))
 if status == "needs-input" {
-reason := "🧑 Waiting for input"
+reason := "✋ Waiting for input"
 if s.Source == data.SourceLocalCopilot {
 if msg := data.FetchLastAssistantMessage(s.ID); msg != "" {
 if len(msg) > 60 {
 msg = msg[:57] + "..."
 }
-reason = "🧑 \"" + msg + "\""
+reason = "✋ \"" + msg + "\""
 }
 }
 m.attention = append(m.attention, attentionItem{Session: s, Reason: reason})
@@ -246,7 +246,7 @@ if m.stats.Idle > 0 {
 summaryParts = append(summaryParts, fmt.Sprintf("💤 %d idle", m.stats.Idle))
 }
 if m.stats.NeedsInput > 0 {
-summaryParts = append(summaryParts, fmt.Sprintf("🧑 %d waiting on you", m.stats.NeedsInput))
+summaryParts = append(summaryParts, fmt.Sprintf("✋ %d waiting on you", m.stats.NeedsInput))
 }
 if m.stats.Done > 0 {
 summaryParts = append(summaryParts, fmt.Sprintf("✅ %d done", m.stats.Done))
@@ -369,7 +369,7 @@ if r.Idle > 0 {
 counts = append(counts, fmt.Sprintf("💤 %d idle", r.Idle))
 }
 if r.NeedsInput > 0 {
-counts = append(counts, fmt.Sprintf("🧑 %d", r.NeedsInput))
+counts = append(counts, fmt.Sprintf("✋ %d", r.NeedsInput))
 }
 if r.Done > 0 {
 counts = append(counts, fmt.Sprintf("✅ %d done", r.Done))
@@ -451,7 +451,7 @@ truncated = truncated[:77] + "..."
 return "❓ \"" + truncated + "\""
 }
 }
-return "🧑 Waiting for input"
+return "✋ Waiting for input"
 case "running":
 if s.Source == data.SourceLocalCopilot {
 if action := data.FetchLastSessionAction(s); action != "" {

--- a/internal/tui/components/mission/mission_test.go
+++ b/internal/tui/components/mission/mission_test.go
@@ -20,7 +20,7 @@ func plainIcon(status string) string {
 	case "failed":
 		return "❌"
 	case "needs-input":
-		return "🧑"
+		return "✋"
 	default:
 		return "⚪"
 	}
@@ -213,7 +213,7 @@ func TestDeriveLastAction_Running(t *testing.T) {
 func TestDeriveLastAction_NeedsInput(t *testing.T) {
 	s := data.Session{Status: "needs-input", Source: data.SourceAgentTask}
 	action := DeriveLastAction(s)
-	if action != "🧑 Waiting for input" {
+	if action != "✋ Waiting for input" {
 		t.Fatalf("expected needs-input action, got %q", action)
 	}
 }

--- a/internal/tui/components/taskdetail/taskdetail.go
+++ b/internal/tui/components/taskdetail/taskdetail.go
@@ -247,7 +247,7 @@ func attentionReason(session *data.Session) string {
 	}
 	status := strings.ToLower(strings.TrimSpace(session.Status))
 	if status == "needs-input" {
-		return "🧑 This session is waiting for your input to continue."
+		return "✋ This session is waiting for your input to continue."
 	}
 	if status == "failed" {
 		return "🚨 This session has failed. Press 'l' to check logs."

--- a/internal/tui/components/tasklist/tasklist.go
+++ b/internal/tui/components/tasklist/tasklist.go
@@ -458,7 +458,7 @@ func isActiveStatus(status string) bool {
 
 func sessionBadge(session data.Session, duplicateCount int) string {
 	if strings.EqualFold(strings.TrimSpace(session.Status), "needs-input") {
-		badge := "🧑 waiting on you"
+		badge := "✋ waiting on you"
 		if duplicateCount > 0 {
 			badge += fmt.Sprintf(" (+%d older)", duplicateCount)
 		}

--- a/internal/tui/components/tasklist/tasklist_test.go
+++ b/internal/tui/components/tasklist/tasklist_test.go
@@ -272,7 +272,7 @@ func TestView_CardShowsAttentionBadges(t *testing.T) {
 	})
 
 	view := model.View()
-	if !strings.Contains(view, "🧑 waiting on you") {
+	if !strings.Contains(view, "✋ waiting on you") {
 		t.Fatalf("expected needs-input badge, got: %s", view)
 	}
 	if !strings.Contains(view, "💤 idle ~30m") {

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -398,7 +398,7 @@ func StatusIcon(status string) string {
 	case "queued":
 		return lipgloss.NewStyle().Foreground(lipgloss.Color("222")).Render("○")
 	case "needs-input":
-		return "🧑"
+		return "✋"
 	case "completed":
 		return "✅"
 	case "failed":

--- a/internal/tui/theme_test.go
+++ b/internal/tui/theme_test.go
@@ -23,7 +23,7 @@ func TestStatusIcon_Queued(t *testing.T) {
 
 func TestStatusIcon_NeedsInput(t *testing.T) {
 	icon := StatusIcon("needs-input")
-	expected := "🧑"
+	expected := "✋"
 	if icon != expected {
 		t.Errorf("expected icon '%s' for needs-input status, got '%s'", expected, icon)
 	}
@@ -172,7 +172,7 @@ func TestAnimatedStatusIcon_StaticForOtherStatuses(t *testing.T) {
 	}{
 		{"completed", "✅"},
 		{"failed", "❌"},
-		{"needs-input", "🧑"},
+		{"needs-input", "✋"},
 		{"unknown", "⚪"},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Replaces 🧑 with ✋ everywhere — status icons, badges, mission control, detail view, docs. The raised hand is neutral and clearly means 'waiting for input.'