### PR TITLE
fix: UX polish — toast feedback for unavailable actions, better empty states

### DIFF
--- a/internal/tui/components/conversation/conversation.go
+++ b/internal/tui/components/conversation/conversation.go
@@ -73,7 +73,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 // View renders the conversation.
 func (m Model) View() string {
 	if !m.ready || len(m.messages) == 0 {
-		return lipgloss.NewStyle().Faint(true).Render("No conversation messages")
+		return lipgloss.NewStyle().Faint(true).Render("No conversation events found for this session.")
 	}
 	return m.viewport.View()
 }

--- a/internal/tui/components/conversation/conversation_test.go
+++ b/internal/tui/components/conversation/conversation_test.go
@@ -16,7 +16,7 @@ func TestSetMessages_Empty(t *testing.T) {
 	m := New(80, 24)
 	m.SetMessages(nil)
 	view := m.View()
-	if !strings.Contains(view, "No conversation messages") {
+	if !strings.Contains(view, "No conversation events found for this session") {
 		t.Errorf("expected empty state message, got %q", view)
 	}
 }

--- a/internal/tui/components/kanban/kanban.go
+++ b/internal/tui/components/kanban/kanban.go
@@ -234,10 +234,19 @@ func (m *Model) renderColumn(col Column, colIdx, width, cardAreaHeight int, focu
 	// Build card lines
 	var cardLines []string
 	if len(col.Sessions) == 0 {
+		hint := "(no sessions)"
+		switch col.Status {
+		case "in-progress":
+			hint = "nothing active"
+		case "idle":
+			hint = "all agents busy"
+		case "done":
+			hint = "no completed sessions"
+		}
 		placeholder := lipgloss.NewStyle().
 			Foreground(lipgloss.Color("241")).
 			Italic(true).
-			Render("(no sessions)")
+			Render(hint)
 		cardLines = append(cardLines, placeholder)
 	} else {
 		for rowIdx, session := range col.Sessions {

--- a/internal/tui/components/kanban/kanban_test.go
+++ b/internal/tui/components/kanban/kanban_test.go
@@ -206,7 +206,7 @@ func TestView_EmptyColumnsShowPlaceholder(t *testing.T) {
 	})
 
 	view := m.View()
-	if !strings.Contains(view, "(no sessions)") {
+	if !strings.Contains(view, "nothing active") && !strings.Contains(view, "all agents busy") && !strings.Contains(view, "no completed sessions") {
 		t.Error("expected placeholder text for empty columns")
 	}
 }

--- a/internal/tui/components/logview/logview.go
+++ b/internal/tui/components/logview/logview.go
@@ -49,6 +49,10 @@ func (m Model) View() string {
 		return "Loading logs..."
 	}
 
+	if m.rawContent == "" && !m.liveSession {
+		return "No log content available. Press esc to go back."
+	}
+
 	if m.content == "" {
 		return m.titleStyle.Render("No logs available")
 	}

--- a/internal/tui/components/logview/logview_test.go
+++ b/internal/tui/components/logview/logview_test.go
@@ -195,8 +195,8 @@ func TestView_EmptyContent(t *testing.T) {
 	m := New(lipgloss.NewStyle(), 80, 24)
 	m.SetContent("")
 	view := m.View()
-	if !strings.Contains(view, "No logs available") {
-		t.Errorf("expected 'No logs available' for empty content, got: %s", view)
+	if !strings.Contains(view, "No log content available") {
+		t.Errorf("expected 'No log content available' for empty content, got: %s", view)
 	}
 }
 

--- a/internal/tui/components/mission/mission.go
+++ b/internal/tui/components/mission/mission.go
@@ -223,7 +223,7 @@ return m.repos[m.cursor].Name
 // View renders the summary dashboard.
 func (m *Model) View() string {
 if len(m.sessions) == 0 {
-return m.titleStyle.Render("  No sessions to display")
+return m.titleStyle.Render("  No sessions found — run gh agent-viz --demo to explore")
 }
 
 w := m.width - 4

--- a/internal/tui/components/tasklist/tasklist.go
+++ b/internal/tui/components/tasklist/tasklist.go
@@ -101,16 +101,15 @@ func (m Model) View() string {
 
 	if len(m.sessions) == 0 {
 		emptyArt := `
-    ╭──────────────────────────────╮
-    │                              │
-    │   ✨ All quiet out here      │
-    │                              │
-    │   No sessions match this     │
-    │   filter. Press 'r' to       │
-    │   refresh or tab to try      │
-    │   another filter.            │
-    │                              │
-    ╰──────────────────────────────╯`
+    ╭───────────────────────────────────────╮
+    │                                       │
+    │   ✨ All quiet on the agent front     │
+    │                                       │
+    │   No sessions found. Try              │
+    │   'gh agent-viz --demo' to explore,   │
+    │   or press 'r' to refresh.            │
+    │                                       │
+    ╰───────────────────────────────────────╯`
 		return m.titleStyle.Render(emptyArt)
 	}
 

--- a/internal/tui/components/tasklist/tasklist_test.go
+++ b/internal/tui/components/tasklist/tasklist_test.go
@@ -104,7 +104,7 @@ func TestViewEmptyAndLoadingStates(t *testing.T) {
 
 	// After data arrives, loading is false — show empty state
 	model.loading = false
-	if got := model.View(); !strings.Contains(got, "All quiet out here") {
+	if got := model.View(); !strings.Contains(got, "All quiet on the agent front") {
 		t.Fatalf("expected empty state, got: %s", got)
 	}
 }
@@ -225,7 +225,7 @@ func TestView_ImprovedEmptyState(t *testing.T) {
 	model.loading = false
 
 	view := model.View()
-	if !strings.Contains(view, "All quiet out here") {
+	if !strings.Contains(view, "All quiet on the agent front") {
 		t.Error("expected whimsical empty state message")
 	}
 	if !strings.Contains(view, "refresh") {

--- a/internal/tui/components/tooltimeline/tooltimeline.go
+++ b/internal/tui/components/tooltimeline/tooltimeline.go
@@ -70,7 +70,7 @@ func (m Model) View() string {
 			Padding(1, 2).
 			Width(m.width - 4)
 		title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("99")).Render("Tool Timeline")
-		return boxStyle.Render(title + "\n\nNo tool executions recorded.")
+		return boxStyle.Render(title + "\n\nNo tool executions recorded for this session.")
 	}
 
 	return m.viewport.View()

--- a/internal/tui/keyhandlers.go
+++ b/internal/tui/keyhandlers.go
@@ -81,13 +81,15 @@ func (m Model) handleListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, m.fetchTaskLog(session.ID, session.Repository)
 		}
-case "c":
-session := m.taskList.SelectedTask()
-if session != nil && session.Source == data.SourceLocalCopilot && session.HasLog {
-m.viewMode = ViewModeLog
-m.showConversation = true
-return m, m.fetchConversation(session.ID)
-}
+	case "c":
+		session := m.taskList.SelectedTask()
+		if session != nil && session.Source == data.SourceLocalCopilot && session.HasLog {
+			m.viewMode = ViewModeLog
+			m.showConversation = true
+			return m, m.fetchConversation(session.ID)
+		} else if session != nil {
+			m.toast.Push("ℹ️", "Conversation", "only available for local Copilot sessions")
+		}
 	case "o":
 		session := m.taskList.SelectedTask()
 		if session != nil {
@@ -154,6 +156,8 @@ return m, m.fetchConversation(session.ID)
 			m.viewMode = ViewModeToolTimeline
 			m.toolTimeline.SetSize(m.ctx.Width-4, m.ctx.Height-8)
 			return m, m.fetchToolTimeline(session.ID)
+		} else if session != nil {
+			m.toast.Push("ℹ️", "Tool Timeline", "only available for local Copilot sessions")
 		}
 	}
 	return m, nil
@@ -175,13 +179,15 @@ func (m Model) handleDetailKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, m.fetchTaskLog(session.ID, session.Repository)
 		}
-case "c":
-session := m.taskList.SelectedTask()
-if session != nil && session.Source == data.SourceLocalCopilot && session.HasLog {
-m.viewMode = ViewModeLog
-m.showConversation = true
-return m, m.fetchConversation(session.ID)
-}
+	case "c":
+		session := m.taskList.SelectedTask()
+		if session != nil && session.Source == data.SourceLocalCopilot && session.HasLog {
+			m.viewMode = ViewModeLog
+			m.showConversation = true
+			return m, m.fetchConversation(session.ID)
+		} else if session != nil {
+			m.toast.Push("ℹ️", "Conversation", "only available for local Copilot sessions")
+		}
 	case "o":
 		session := m.taskList.SelectedTask()
 		if session != nil {
@@ -198,6 +204,8 @@ return m, m.fetchConversation(session.ID)
 			m.viewMode = ViewModeToolTimeline
 			m.toolTimeline.SetSize(m.ctx.Width-4, m.ctx.Height-8)
 			return m, m.fetchToolTimeline(session.ID)
+		} else if session != nil {
+			m.toast.Push("ℹ️", "Tool Timeline", "only available for local Copilot sessions")
 		}
 	case "d":
 		session := m.taskList.SelectedTask()


### PR DESCRIPTION
Keys that don't apply to the selected session now show an informative toast instead of silently doing nothing. Empty states in all views now explain what to do next.

### Changes

**Toast feedback for silent key failures:**
- `c` key (conversation) in list/detail view: shows toast when not a local Copilot session
- `t` key (tool timeline) in list/detail view: shows toast when not a local Copilot session

**Better empty states:**
- Kanban columns: contextual placeholders ("nothing active", "all agents busy", "no completed sessions")
- Mission control: mentions `--demo` flag
- Log view: helpful message when no content available
- Conversation view: clearer empty message
- Tool timeline: more descriptive empty message
- Task list: updated empty state with `--demo` hint and refreshed copy