### PR TITLE
fix: resolve lint errors and add GoReleaser for distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,34 @@
+version: 2
+
+builds:
+  - id: gh-agent-viz
+    main: ./gh-agent-viz.go
+    binary: gh-agent-viz
+    ldflags:
+      - -s -w -X github.com/maxbeizer/gh-agent-viz/cmd.Version={{.Version}}
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - id: default
+    format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,9 @@ var (
 	demoFlag  bool
 )
 
-// rootCmd represents the base command
+// Version is set by goreleaser at build time.
+var Version = "dev"
+
 var rootCmd = &cobra.Command{
 	Use:   "gh-agent-viz",
 	Short: "Interactive terminal UI for visualizing GitHub Copilot agent sessions",
@@ -49,7 +51,7 @@ func Execute() {
 
 func init() {
 	// Version (GoReleaser injects the real version at build time)
-	rootCmd.Version = "dev"
+	rootCmd.Version = Version
 
 	// Add flags
 	rootCmd.Flags().StringVarP(&repoFlag, "repo", "R", "", "Scope to a specific repository (format: owner/repo)")

--- a/internal/tui/components/kanban/kanban.go
+++ b/internal/tui/components/kanban/kanban.go
@@ -180,18 +180,7 @@ func (m *Model) RowCursor() int {
 
 // ColumnWidth computes the width for each column based on non-empty column count.
 func (m *Model) ColumnWidth() int {
-	nonEmpty := 0
-	for _, col := range m.columns {
-		if len(col.Sessions) > 0 {
-			nonEmpty++
-		}
-	}
 	count := len(m.columns)
-	if nonEmpty > 0 {
-		count = nonEmpty
-	}
-	// Always show all columns, but size based on visible count
-	count = len(m.columns)
 	if count == 0 {
 		return m.width
 	}

--- a/internal/tui/components/mission/mission.go
+++ b/internal/tui/components/mission/mission.go
@@ -292,10 +292,6 @@ lines = append(lines, "")
 lines = append(lines, "  "+sectionHead.Render("Needs your attention"))
 lines = append(lines, "  "+dim.Render(strings.Repeat("─", w-4)))
 for _, item := range m.attention {
-title := item.Session.Title
-if len(title) > 30 {
-title = title[:27] + "..."
-}
 repo := item.Session.Repository
 if repo == "" {
 repo = "local"

--- a/internal/tui/components/tasklist/tasklist.go
+++ b/internal/tui/components/tasklist/tasklist.go
@@ -645,13 +645,6 @@ func (m *Model) SetAnimFrame(frame int) {
 	m.animFrame = frame
 }
 
-// currentStatusIcon returns the animated icon if available, otherwise the static icon.
-func (m Model) currentStatusIcon(status string) string {
-	if m.animStatusIcon != nil {
-		return m.animStatusIcon(status, m.animFrame)
-	}
-	return m.statusIcon(status)
-}
 
 func (m Model) pageSize() int {
 	// Use full height (minus minimal chrome)

--- a/internal/tui/components/tooltimeline/tooltimeline.go
+++ b/internal/tui/components/tooltimeline/tooltimeline.go
@@ -97,11 +97,6 @@ func (m *Model) renderTimeline() string {
 	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
 	iconStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
 
-	innerWidth := m.width - 8
-	if innerWidth < 20 {
-		innerWidth = 20
-	}
-
 	var lines []string
 	var prevTime string
 	for _, ev := range m.events {

--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -144,39 +144,6 @@ func (m *Model) updateFooterHints() {
 	}
 }
 
-func canShowLogs(session *data.Session) bool {
-	if session == nil || strings.TrimSpace(session.ID) == "" {
-		return false
-	}
-	if session.Source == data.SourceAgentTask {
-		return true
-	}
-	// Local sessions can show logs if they have an events.jsonl file
-	return session.HasLog
-}
-
-func canOpenPR(session *data.Session) bool {
-	if session == nil {
-		return false
-	}
-	// Has explicit PR info
-	if strings.TrimSpace(session.PRURL) != "" {
-		return true
-	}
-	if session.PRNumber > 0 && strings.TrimSpace(session.Repository) != "" {
-		return true
-	}
-	// Can discover PR by branch lookup
-	return strings.TrimSpace(session.Repository) != "" && strings.TrimSpace(session.Branch) != ""
-}
-
-func canResumeLocalSession(session *data.Session) bool {
-	if session == nil || session.Source != data.SourceLocalCopilot || strings.TrimSpace(session.ID) == "" {
-		return false
-	}
-	status := strings.ToLower(strings.TrimSpace(session.Status))
-	return status == "running" || status == "queued" || status == "needs-input"
-}
 
 // canShowDiff returns true when the session has a PR or can discover one
 func canShowDiff(session *data.Session) bool {


### PR DESCRIPTION
## Summary

Fixes all golangci-lint errors and adds GoReleaser configuration for cross-platform binary distribution.

### Lint fixes
- Remove unused `currentStatusIcon` method from tasklist
- Remove unused `canShowLogs`, `canOpenPR`, `canResumeLocalSession` helpers
- Fix ineffectual assignment to `count` in kanban `ColumnWidth()`
- Remove unused `innerWidth` computation in tooltimeline
- Remove unused `title` truncation in mission attention list

### Release infrastructure
- Add `.goreleaser.yml` for cross-platform builds (linux/darwin/windows, amd64/arm64)
- Add `.github/workflows/release.yml` to run GoReleaser on tag push
- Wire `cmd.Version` variable for build-time version injection via ldflags