### PR TITLE
feat: mass dismiss completed sessions with Shift-X

### DIFF
--- a/internal/tui/components/help/help.go
+++ b/internal/tui/components/help/help.go
@@ -63,6 +63,7 @@ func (m Model) View() string {
 		formatKey("o", "open PR") + "\n" +
 		formatKey("s", "resume session") + "\n" +
 		formatKey("x", "dismiss") + "\n" +
+		formatKey("X", "dismiss all done") + "\n" +
 		formatKey("r", "refresh") + "\n" +
 		formatKey("p", "toggle preview")
 

--- a/internal/tui/components/tasklist/tasklist.go
+++ b/internal/tui/components/tasklist/tasklist.go
@@ -405,6 +405,38 @@ func (m *Model) DismissSelected() {
 	}
 }
 
+// DismissCompleted removes all completed sessions from view and returns the count dismissed.
+func (m *Model) DismissCompleted() int {
+	count := 0
+	for _, s := range m.sessions {
+		if strings.EqualFold(strings.TrimSpace(s.Status), "completed") && s.ID != "" {
+			m.dismissedIDs[s.ID] = struct{}{}
+			if m.dismissedStore != nil {
+				m.dismissedStore.Add(s.ID)
+			}
+			count++
+		}
+	}
+	if count == 0 {
+		return 0
+	}
+	// Rebuild session list without dismissed
+	newSessions := make([]data.Session, 0, len(m.sessions)-count)
+	for _, s := range m.sessions {
+		if _, dismissed := m.dismissedIDs[s.ID]; !dismissed {
+			newSessions = append(newSessions, s)
+		}
+	}
+	m.sessions = newSessions
+	if m.rowCursor >= len(m.sessions) {
+		m.rowCursor = len(m.sessions) - 1
+	}
+	if m.rowCursor < 0 {
+		m.rowCursor = 0
+	}
+	return count
+}
+
 // SelectedTask returns the currently selected session
 func (m Model) SelectedTask() *data.Session {
 	if len(m.sessions) == 0 {

--- a/internal/tui/components/tasklist/tasklist_dismiss_test.go
+++ b/internal/tui/components/tasklist/tasklist_dismiss_test.go
@@ -1,0 +1,87 @@
+package tasklist
+
+import (
+	"testing"
+	"time"
+
+	"github.com/maxbeizer/gh-agent-viz/internal/data"
+)
+
+func TestDismissCompletedRemovesCompletedSessions(t *testing.T) {
+	model := newModel()
+	now := time.Now()
+	model.SetTasks([]data.Session{
+		{ID: "1", Status: "running", Title: "Running", UpdatedAt: now},
+		{ID: "2", Status: "completed", Title: "Done 1", UpdatedAt: now.Add(-1 * time.Hour)},
+		{ID: "3", Status: "completed", Title: "Done 2", UpdatedAt: now.Add(-2 * time.Hour)},
+		{ID: "4", Status: "failed", Title: "Failed", UpdatedAt: now.Add(-3 * time.Hour)},
+	})
+
+	count := model.DismissCompleted()
+	if count != 2 {
+		t.Fatalf("expected 2 dismissed, got %d", count)
+	}
+	if len(model.sessions) != 2 {
+		t.Fatalf("expected 2 remaining sessions, got %d", len(model.sessions))
+	}
+	for _, s := range model.sessions {
+		if s.Status == "completed" {
+			t.Fatalf("completed session %s should have been dismissed", s.ID)
+		}
+	}
+}
+
+func TestDismissCompletedReturnsZeroWhenNoneCompleted(t *testing.T) {
+	model := newModel()
+	now := time.Now()
+	model.SetTasks([]data.Session{
+		{ID: "1", Status: "running", Title: "Running", UpdatedAt: now},
+		{ID: "2", Status: "failed", Title: "Failed", UpdatedAt: now.Add(-1 * time.Hour)},
+	})
+
+	count := model.DismissCompleted()
+	if count != 0 {
+		t.Fatalf("expected 0 dismissed, got %d", count)
+	}
+	if len(model.sessions) != 2 {
+		t.Fatalf("expected 2 sessions unchanged, got %d", len(model.sessions))
+	}
+}
+
+func TestDismissCompletedClampsCursor(t *testing.T) {
+	model := newModel()
+	now := time.Now()
+	model.SetTasks([]data.Session{
+		{ID: "1", Status: "completed", Title: "Done 1", UpdatedAt: now},
+		{ID: "2", Status: "completed", Title: "Done 2", UpdatedAt: now.Add(-1 * time.Hour)},
+		{ID: "3", Status: "running", Title: "Running", UpdatedAt: now.Add(-2 * time.Hour)},
+	})
+	// Move cursor to the end
+	model.rowCursor = 2
+
+	count := model.DismissCompleted()
+	if count != 2 {
+		t.Fatalf("expected 2 dismissed, got %d", count)
+	}
+	if model.rowCursor != 0 {
+		t.Fatalf("expected cursor clamped to 0, got %d", model.rowCursor)
+	}
+}
+
+func TestDismissCompletedHandlesCaseInsensitiveStatus(t *testing.T) {
+	model := newModel()
+	now := time.Now()
+	model.SetTasks([]data.Session{
+		{ID: "1", Status: "Completed", Title: "Done 1", UpdatedAt: now},
+		{ID: "2", Status: "COMPLETED", Title: "Done 2", UpdatedAt: now.Add(-1 * time.Hour)},
+		{ID: "3", Status: "running", Title: "Running", UpdatedAt: now.Add(-2 * time.Hour)},
+	})
+
+	count := model.DismissCompleted()
+	if count != 2 {
+		t.Fatalf("expected 2 dismissed, got %d", count)
+	}
+	if len(model.sessions) != 1 {
+		t.Fatalf("expected 1 remaining session, got %d", len(model.sessions))
+	}
+}

--- a/internal/tui/keyhandlers.go
+++ b/internal/tui/keyhandlers.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"fmt"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/maxbeizer/gh-agent-viz/internal/data"
 )
@@ -102,6 +104,13 @@ func (m Model) handleListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "x":
 		m.taskList.DismissSelected()
+	case "X":
+		count := m.taskList.DismissCompleted()
+		if count > 0 {
+			m.toast.Push("🧹", "Dismissed", fmt.Sprintf("%d completed session(s) cleared", count))
+		} else {
+			m.toast.Push("ℹ️", "Nothing to dismiss", "no completed sessions found")
+		}
 	case "r":
 		return m, m.fetchTasks
 	case "p":

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -26,6 +26,7 @@ type Keybindings struct {
 	ShowHelp       key.Binding
 	OpenRepo       key.Binding
 	FileIssue      key.Binding
+	MassDismiss    key.Binding
 }
 
 // NewKeybindings creates the default key bindings for the TUI
@@ -118,6 +119,10 @@ func NewKeybindings() Keybindings {
 		FileIssue: key.NewBinding(
 			key.WithKeys("@"),
 			key.WithHelp("@", "file tool issue"),
+		),
+		MassDismiss: key.NewBinding(
+			key.WithKeys("X"),
+			key.WithHelp("X", "dismiss done"),
 		),
 	}
 }


### PR DESCRIPTION
Adds bulk dismiss for completed sessions. Press X (shift-x) in the list view to clear all completed sessions at once. Shows a toast with the count of dismissed sessions.

Closes #183