### PR TITLE
fix: add retry backoff and TTL caching for data fetching

### DIFF
--- a/internal/data/agentapi.go
+++ b/internal/data/agentapi.go
@@ -213,10 +213,31 @@ func normalizeStatus(status string) string {
 	}
 }
 
+// maxRetries is the maximum number of retry attempts for gh CLI commands.
+const maxRetries = 3
+
 func runGH(args ...string) ([]byte, error) {
-	output, err := execCommand("gh", args...).CombinedOutput()
-	if debugEnabled {
-		logDebugEntry(args, output, err)
+	var output []byte
+	var err error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		output, err = execCommand("gh", args...).CombinedOutput()
+		if debugEnabled {
+			logDebugEntry(args, output, err)
+		}
+		if err == nil {
+			return output, nil
+		}
+		// Don't retry on known non-transient errors
+		outStr := string(output)
+		if strings.Contains(outStr, "unknown flag") ||
+			strings.Contains(outStr, "not found") ||
+			strings.Contains(outStr, "session ID is required") {
+			return output, err
+		}
+		if attempt < maxRetries {
+			backoff := time.Duration(1<<uint(attempt)) * 100 * time.Millisecond // 100ms, 200ms, 400ms
+			time.Sleep(backoff)
+		}
 	}
 	return output, err
 }

--- a/internal/data/localsession.go
+++ b/internal/data/localsession.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -31,8 +32,46 @@ type LocalSessionWorkspace struct {
 	ConversationHistory []map[string]interface{} `yaml:"conversation_history"`
 }
 
+var (
+	localSessionCache     []Session
+	localSessionCacheTime time.Time
+	localSessionCacheTTL  = 15 * time.Second
+	localSessionCacheMu   sync.Mutex
+)
+
+// ResetLocalSessionCache clears the local session cache, forcing the next
+// FetchLocalSessions call to re-read from disk. Exported for testing.
+func ResetLocalSessionCache() {
+	localSessionCacheMu.Lock()
+	defer localSessionCacheMu.Unlock()
+	localSessionCache = nil
+	localSessionCacheTime = time.Time{}
+}
+
 // FetchLocalSessions retrieves local Copilot CLI sessions from ~/.copilot/session-state/
+// Results are cached for 15 seconds.
 func FetchLocalSessions() ([]Session, error) {
+	localSessionCacheMu.Lock()
+	defer localSessionCacheMu.Unlock()
+
+	if localSessionCache != nil && time.Since(localSessionCacheTime) < localSessionCacheTTL {
+		// Return a copy so callers can safely mutate without corrupting the cache.
+		out := make([]Session, len(localSessionCache))
+		copy(out, localSessionCache)
+		return out, nil
+	}
+
+	sessions, err := fetchLocalSessionsUncached()
+	if err != nil {
+		return nil, err
+	}
+	localSessionCache = sessions
+	localSessionCacheTime = time.Now()
+	return sessions, nil
+}
+
+// fetchLocalSessionsUncached retrieves local Copilot CLI sessions from ~/.copilot/session-state/
+func fetchLocalSessionsUncached() ([]Session, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get home directory: %w", err)

--- a/internal/data/localsession_test.go
+++ b/internal/data/localsession_test.go
@@ -386,6 +386,7 @@ updated_at: %q
 }
 
 func TestFetchLocalSessions_NoDirectory(t *testing.T) {
+	ResetLocalSessionCache()
 	// Override home dir to a temp location without .copilot
 	tmpDir := t.TempDir()
 	originalHome := os.Getenv("HOME")
@@ -403,6 +404,7 @@ func TestFetchLocalSessions_NoDirectory(t *testing.T) {
 }
 
 func TestFetchLocalSessions_WithSessions(t *testing.T) {
+	ResetLocalSessionCache()
 	tmpDir := t.TempDir()
 	sessionDir := filepath.Join(tmpDir, ".copilot", "session-state")
 
@@ -476,6 +478,7 @@ last_activity: "2026-02-15T04:30:00Z"
 }
 
 func TestFetchLocalSessions_EventsJSONLMtimeRefinesUpdatedAt(t *testing.T) {
+	ResetLocalSessionCache()
 	tmpDir := t.TempDir()
 	sessionDir := filepath.Join(tmpDir, ".copilot", "session-state", "session-active")
 

--- a/internal/data/tokenusage.go
+++ b/internal/data/tokenusage.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -38,9 +39,48 @@ type responseBlock struct {
 
 var sessionFlushRe = regexp.MustCompile(`Flushed \d+ events to session ([0-9a-fA-F-]{36})`)
 
+var (
+	tokenUsageCache     map[string]*TokenUsage
+	tokenUsageCacheTime time.Time
+	tokenUsageCacheTTL  = 60 * time.Second
+	tokenUsageCacheMu   sync.Mutex
+)
+
 // FetchTokenUsage parses recent Copilot CLI log files and returns per-session
-// token usage. Only files modified in the last 7 days are parsed.
+// token usage. Results are cached for 60 seconds.
 func FetchTokenUsage() (map[string]*TokenUsage, error) {
+	tokenUsageCacheMu.Lock()
+	defer tokenUsageCacheMu.Unlock()
+
+	if tokenUsageCache != nil && time.Since(tokenUsageCacheTime) < tokenUsageCacheTTL {
+		// Return a copy so callers can safely mutate without corrupting the cache.
+		out := make(map[string]*TokenUsage, len(tokenUsageCache))
+		for k, v := range tokenUsageCache {
+			dup := *v
+			out[k] = &dup
+		}
+		return out, nil
+	}
+
+	usage, err := fetchTokenUsageUncached()
+	if err != nil {
+		return nil, err
+	}
+	tokenUsageCache = usage
+	tokenUsageCacheTime = time.Now()
+	return usage, nil
+}
+
+// ResetTokenUsageCache clears the token usage cache, forcing the next
+// FetchTokenUsage call to re-parse log files. Exported for testing.
+func ResetTokenUsageCache() {
+	tokenUsageCacheMu.Lock()
+	defer tokenUsageCacheMu.Unlock()
+	tokenUsageCache = nil
+	tokenUsageCacheTime = time.Time{}
+}
+
+func fetchTokenUsageUncached() (map[string]*TokenUsage, error) {
 	return fetchTokenUsageFromDir(defaultLogDir())
 }
 


### PR DESCRIPTION
Addresses performance concerns around subprocess calls and redundant data fetching:

- **Exponential backoff**: runGH now retries transient failures up to 3 times with 100ms→200ms→400ms backoff. Non-transient errors (unknown flag, not found) are not retried.
- **Token usage cache**: FetchTokenUsage results cached for 60 seconds since log files rarely change mid-session.
- **Local session cache**: FetchLocalSessions results cached for 15 seconds to avoid redundant YAML parsing on every refresh cycle.

Closes #184