### PR TITLE
Cap session count and eliminate prevSessions map churn

### DIFF
--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -13,6 +14,10 @@ import (
 	"github.com/maxbeizer/gh-agent-viz/internal/tui/components/header"
 	"github.com/maxbeizer/gh-agent-viz/internal/tui/components/statsbar"
 )
+
+// maxSessions is the upper bound on accumulated sessions kept in memory.
+// When exceeded, the oldest sessions (by UpdatedAt) are discarded.
+const maxSessions = 500
 
 // sessionFingerprint returns a hash summarising session IDs, statuses, and
 // update timestamps so callers can cheaply detect whether a refresh actually
@@ -254,6 +259,14 @@ func (m *Model) mergeSessions(newSessions []data.Session) {
 			m.allSessions = append(m.allSessions, s)
 			existingIdx[s.ID] = len(m.allSessions) - 1
 		}
+	}
+
+	// Cap session count to prevent unbounded memory growth
+	if len(m.allSessions) > maxSessions {
+		sort.SliceStable(m.allSessions, func(i, j int) bool {
+			return m.allSessions[i].UpdatedAt.After(m.allSessions[j].UpdatedAt)
+		})
+		m.allSessions = m.allSessions[:maxSessions]
 	}
 
 	// Filter dismissed

--- a/internal/tui/helpers_test.go
+++ b/internal/tui/helpers_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -67,5 +68,43 @@ func TestSessionFingerprint_SameDataDifferentOrder(t *testing.T) {
 	// This is fine because session order is deterministic.
 	if fp1 == fp2 {
 		t.Fatal("different ordering should produce different fingerprints")
+	}
+}
+
+func TestMergeSessions_CapsAtMaxSessions(t *testing.T) {
+	m := &Model{ctx: NewProgramContext()}
+	// Generate more sessions than the cap
+	sessions := make([]data.Session, maxSessions+100)
+	for i := range sessions {
+		sessions[i] = data.Session{
+			ID:        fmt.Sprintf("session-%d", i),
+			Status:    "completed",
+			UpdatedAt: time.Unix(int64(i), 0),
+		}
+	}
+	m.mergeSessions(sessions)
+
+	if len(m.allSessions) != maxSessions {
+		t.Fatalf("expected %d sessions after cap, got %d", maxSessions, len(m.allSessions))
+	}
+
+	// Verify the newest sessions were kept (highest UpdatedAt)
+	for _, s := range m.allSessions {
+		if s.UpdatedAt.Unix() < int64(100) {
+			t.Fatalf("oldest sessions should have been trimmed, found UpdatedAt=%d", s.UpdatedAt.Unix())
+		}
+	}
+}
+
+func TestMergeSessions_BelowCapUnchanged(t *testing.T) {
+	m := &Model{ctx: NewProgramContext()}
+	sessions := []data.Session{
+		{ID: "a", Status: "running", UpdatedAt: time.Unix(1000, 0)},
+		{ID: "b", Status: "completed", UpdatedAt: time.Unix(2000, 0)},
+	}
+	m.mergeSessions(sessions)
+
+	if len(m.allSessions) != 2 {
+		t.Fatalf("expected 2 sessions, got %d", len(m.allSessions))
 	}
 }

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -164,8 +164,9 @@ func NewModel(repo string, debug bool, demo bool, snapshotPath string) Model {
 		ready:       false,
 		repo:        repo,
 		refreshInt:  time.Duration(refreshSeconds) * time.Second,
-		toast:       toast.New(),
-		demo:        demo,
+		toast:        toast.New(),
+		prevSessions: make(map[string]string, 64),
+		demo:         demo,
 		snapshotPath: snapshotPath,
 		loadSpinner: sp,
 		loadTagline: tagline,
@@ -248,7 +249,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Initial load complete — snapshot prevSessions and start refresh timer
 		if !m.initialLoadDone {
 			m.initialLoadDone = true
-			m.prevSessions = make(map[string]string, len(m.allSessions))
+			clear(m.prevSessions)
 			for _, s := range m.allSessions {
 				m.prevSessions[s.ID] = s.Status
 			}
@@ -293,14 +294,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// First load: pick the best default tab based on actual data
 			m.ctx.StatusFilter = smartDefaultFilter(msg.counts)
 			m.taskList.SetLoading(true)
-			m.prevSessions = make(map[string]string, len(msg.tasks))
+			clear(m.prevSessions)
 			for _, s := range msg.tasks {
 				m.prevSessions[s.ID] = s.Status
 			}
 			return m, m.fetchTasks
 		}
 		// Update prevSessions for next comparison
-		m.prevSessions = make(map[string]string, len(msg.tasks))
+		clear(m.prevSessions)
 		for _, s := range msg.tasks {
 			m.prevSessions[s.ID] = s.Status
 		}


### PR DESCRIPTION
## Summary

Two targeted memory improvements:

### 1. Session count cap (Closes #203)
`mergeSessions()` now enforces a `maxSessions = 500` ceiling. When exceeded, sessions are sorted by `UpdatedAt` and the oldest are trimmed. This prevents unbounded memory growth for users with extensive agent history.

### 2. prevSessions map reuse (Closes #204)
The `prevSessions` map (used for toast notification diffing) is now pre-allocated once in `NewModel()` and cleared with `clear()` each cycle instead of re-allocated with `make()`. Reduces per-refresh GC pressure.

## Testing
- Added `TestMergeSessions_CapsAtMaxSessions` — verifies trim to 500 and that newest sessions are retained
- Added `TestMergeSessions_BelowCapUnchanged` — verifies no-op when under limit
- Full test suite passes with `-race`